### PR TITLE
🐞fix(win): disable cursor jump and simplify text truncation

### DIFF
--- a/home/dotfiles/glzr/glzr/glazewm/config.yaml
+++ b/home/dotfiles/glzr/glzr/glazewm/config.yaml
@@ -5,7 +5,7 @@ general:
   focus_follows_cursor: true
   toggle_workspace_on_refocus: true
   cursor_jump:
-    enabled: true
+    enabled: false
     trigger: "window_focus"
   hide_method: "cloak"
   show_all_in_taskbar: false

--- a/home/dotfiles/glzr/glzr/zebar/default/with-glazewm.html
+++ b/home/dotfiles/glzr/glzr/zebar/default/with-glazewm.html
@@ -52,10 +52,10 @@
 
         // Truncate text if it's longer than maxLength.
         function truncateText(text, maxLength) {
-          if (text.length > maxLength) {
-            return text.substring(0, maxLength) + '...';
-          }
-          return text;
+          if (!text) return text;
+            return text.length > maxLength
+            ? text.substring(0, maxLength) + '...'
+            : text;
         }
 
         // Get icon to show for current audio volume.


### PR DESCRIPTION
- disable `cursor_jump` feature in `GlazeWM` config
- refactor `truncateText` function in `Zebar` for better null handling and readability
- replace nested if statement with ternary operator for more concise code