### PR TITLE
💄style: format DAP keymaps and fix description in LunarVim config

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/lv-settings/dap.lua
+++ b/home/dotfiles/lvim/lvim/lua/lv-settings/dap.lua
@@ -2,7 +2,17 @@
 -- enabled dap
 lvim.builtin.dap.active = true
 -- keymaps
-vim.keymap.set("n", "<F5>", ":lua require'dap'.continue()<CR>", { noremap = true, silent = true, desc = "Continue" })
-vim.keymap.set("n", "<F10>", ":lua require'dap'.step_over()<CR>", { noremap = true, silent = true, desc = "Step over" })
-vim.keymap.set("n", "<F11>", ":lua require'dap'.step_into()<CR>", { noremap = true, silent = true, desc = "Step into" })
-vim.keymap.set("n", "<F12>", ":lua require'dap'.step_out()<CR>", { noremap = true, silent = true, desc = "Step" })
+vim.keymap.set("n", "<F5>", ":lua require('dap').continue()<CR>", { noremap = true, silent = true, desc = "Continue" })
+vim.keymap.set(
+  "n",
+  "<F10>",
+  ":lua require('dap').step_over()<CR>",
+  { noremap = true, silent = true, desc = "Step over" }
+)
+vim.keymap.set(
+  "n",
+  "<F11>",
+  ":lua require('dap').step_into()<CR>",
+  { noremap = true, silent = true, desc = "Step into" }
+)
+vim.keymap.set("n", "<F12>", ":lua require('dap').step_out()<CR>", { noremap = true, silent = true, desc = "Step out" })


### PR DESCRIPTION
- format keymap configurations for better readability by splitting long lines
- standardize quotes around `dap` module references
- fix description of F12 keymap from `Step` to `Step out`