### PR TITLE
💄style: truncate network SSID to 10 characters

### DIFF
--- a/home/dotfiles/glzr/glzr/zebar/default/with-glazewm.html
+++ b/home/dotfiles/glzr/glzr/zebar/default/with-glazewm.html
@@ -198,7 +198,7 @@
               {output.network && (
                 <div className="network">
                   {getNetworkIcon(output.network)}
-                  {output.network.defaultGateway?.ssid}
+                  {truncateText(output.network.defaultGateway?.ssid, 10)}
                 </div>
               )}
 


### PR DESCRIPTION
- add truncation to network SSID display to optimize visual space
- improve readability by preventing long SSID names from overflowing