### PR TITLE
💄style: adjust text truncation length in media display

### DIFF
--- a/home/dotfiles/glzr/glzr/zebar/default/with-glazewm.html
+++ b/home/dotfiles/glzr/glzr/zebar/default/with-glazewm.html
@@ -148,7 +148,7 @@
               {output.media && output.media.currentSession && (
                 <div className="media">
                   {getMediaPlayingIcon(output.media.currentSession?.isPlaying)}
-                  {`${truncateText(output.media.currentSession?.title, 15)} - ${truncateText(output.media.currentSession?.artist, 15)}`}
+                  {`${truncateText(output.media.currentSession?.title, 12)} - ${truncateText(output.media.currentSession?.artist, 12)}`}
                 </div>
               )}
 


### PR DESCRIPTION
- reduce the maximum length of displayed media information from 15 to 12  characters
- improve readability of media title and artist text in the UI
- prevent potential overflow issues in the media display section