### PR TITLE
✨feat(lunarvim): add auto-restore last cursor position feature

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/config/autocommands.lua
+++ b/home/dotfiles/lvim/lvim/lua/config/autocommands.lua
@@ -13,4 +13,28 @@ lvim.autocommands = {
       end,
     },
   },
+  -- restore last cursor position
+  {
+    "BufRead",
+    {
+      pattern = { "*" },
+      callback = function(opts)
+        vim.api.nvim_create_autocmd("BufWinEnter", {
+          once = true,
+          buffer = opts.buf,
+          callback = function()
+            local ft = vim.bo[opts.buf].filetype
+            local last_known_line = vim.api.nvim_buf_get_mark(opts.buf, '"')[1]
+            if
+              not (ft:match("commit") and ft:match("rebase"))
+              and last_known_line > 1
+              and last_known_line <= vim.api.nvim_buf_line_count(opts.buf)
+            then
+              vim.api.nvim_feedkeys([[g`"]], "nx", false)
+            end
+          end,
+        })
+      end,
+    },
+  },
 }


### PR DESCRIPTION
- add autocmd to restore the last known cursor position when reopening files
- skip restoration for git commit and rebase buffers
- ensure cursor position is within valid buffer range