### PR TITLE
🐞fix(win): adjust window title length limit from 100 to 75 chars on `…

### DIFF
--- a/home/dotfiles/glzr/glzr/zebar/default/with-glazewm.html
+++ b/home/dotfiles/glzr/glzr/zebar/default/with-glazewm.html
@@ -136,7 +136,7 @@
                   {output.glazewm.allWindows.map(window => (
                     window && window.hasFocus ? (
                       <div>
-                        {truncateText(window.title, 100)}
+                        {truncateText(window.title, 75)}
                       </div>
                     ) : null
                   ))}


### PR DESCRIPTION
- reduce the maximum length of displayed window titles from 100 to 75 characters to improve visual appearance
- prevent window titles from taking up too much space in the UI