### PR TITLE
👷chore(nix): update `jrp` package to v2

### DIFF
--- a/pkglist/go/pkglist.txt
+++ b/pkglist/go/pkglist.txt
@@ -9,6 +9,6 @@ github.com/sheepla/og@latest
 github.com/skanehira/rtty@latest
 github.com/Songmu/gocredits/cmd/gocredits@latest
 github.com/wadey/gocovmerge@latest
-github.com/yanosea/jrp@latest
+github.com/yanosea/jrp/v2/app/presentation/cli/jrp@latest
 github.com/yanosea/mindnum/app/presentation/cli/mindnum@latest
 golang.org/x/tools/cmd/godoc@latest


### PR DESCRIPTION
- update package path for jrp from `github.com/yanosea/jrp` to `github.com/yanosea/jrp/v2/app/presentation/cli/jrp`
- this change reflects the new version (v2) of the `jrp` package