### PR TITLE
💄style(lunarvim): reorganize keymaps and standardize command descript…

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/lv-settings/which-key.lua
+++ b/home/dotfiles/lvim/lvim/lua/lv-settings/which-key.lua
@@ -61,20 +61,22 @@ lvim.builtin.which_key.mappings["C"] = {
 lvim.builtin.which_key.mappings["<SPACE>"] = { "<CMD>FuzzyMotion<CR>", "FuzzyMotion" }
 -- lsp
 table.insert(lvim.builtin.which_key.mappings["l"], {
-  -- todo-comments
-  -- TodoLocList
-  t = { "<CMD>TodoLocList<CR>", "TodoLocList" },
+  name = "+LSP",
+  -- outline
+  -- Outline
+  o = { "<CMD>Outline<CR>", "Outline" },
   -- trouble
   -- Trouble diagnostics toggle
-  T = { "<CMD>Trouble diagnostics toggle<CR>", "TroubleDiagnostics" },
+  t = { "<CMD>Trouble diagnostics toggle<CR>", "TroubleDiagnostics" },
+  -- todo-comments
+  -- TodoLocList
+  T = { "<CMD>TodoLocList<CR>", "TodoLocList" },
 })
--- outline
-lvim.builtin.which_key.mappings["o"] = { "<CMD>Outline<CR>", "Outline" }
 -- toggleterm
 lvim.builtin.which_key.mappings["t"] = { "<CMD>ToggleTerm<CR>", "ToggleTerm" }
 -- yankring
 lvim.builtin.which_key.mappings["y"] = {
   name = "+Yankring",
   -- YRShow
-  h = { "<CMD>YRShow<CR>", "YankRing show" },
+  h = { "<CMD>YRShow<CR>", "YankRing Show" },
 }

--- a/home/dotfiles/lvim/lvim/lua/user-plugins/utils/trouble.lua
+++ b/home/dotfiles/lvim/lvim/lua/user-plugins/utils/trouble.lua
@@ -4,34 +4,34 @@ table.insert(lvim.plugins, {
   dependencies = { "nvim-tree/nvim-web-devicons" },
   event = { "BufRead", "BufEnter" },
   keys = {
-    {
-      "<LEADER>xx",
-      "<CMD>Trouble diagnostics toggle<cr>",
-      desc = "Diagnostics (Trouble)",
-    },
+    -- {
+    --   "<LEADER>xx",
+    --   "<CMD>Trouble diagnostics toggle<CR>",
+    --   desc = "Diagnostics (Trouble)",
+    -- },
     {
       "<LEADER>xX",
-      "<CMD>Trouble diagnostics toggle filter.buf=0<cr>",
+      "<CMD>Trouble diagnostics toggle filter.buf=0<CR>",
       desc = "Buffer Diagnostics (Trouble)",
     },
-    {
-      "<LEADER>cs",
-      "<CMD>Trouble symbols toggle focus=false<cr>",
-      desc = "Symbols (Trouble)",
-    },
+    -- {
+    --   "<LEADER>cs",
+    --   "<CMD>Trouble symbols toggle focus=false<CR>",
+    --   desc = "Symbols (Trouble)",
+    -- },
     {
       "<LEADER>cl",
-      "<CMD>Trouble lsp toggle focus=false win.position=right<cr>",
+      "<CMD>Trouble lsp toggle focus=false win.position=right<CR>",
       desc = "LSP Definitions / references / ... (Trouble)",
     },
     {
       "<LEADER>xL",
-      "<CMD>Trouble loclist toggle<cr>",
+      "<CMD>Trouble loclist toggle<CR>",
       desc = "Location List (Trouble)",
     },
     {
       "<LEADER>xQ",
-      "<CMD>Trouble qflist toggle<cr>",
+      "<CMD>Trouble qflist toggle<CR>",
       desc = "Quickfix List (Trouble)",
     },
   },
@@ -68,8 +68,8 @@ table.insert(lvim.plugins, {
       R = "toggle_refresh",
       q = "close",
       o = "jump_close",
-      ["<esc>"] = "cancel",
-      ["<cr>"] = "jump",
+      ["<ESC>"] = "cancel",
+      ["<CR>"] = "jump",
       ["<2-leftmouse>"] = "jump",
       ["<c-s>"] = "jump_split",
       ["<c-v>"] = "jump_vsplit",
@@ -173,7 +173,4 @@ table.insert(lvim.plugins, {
       },
     },
   },
-  init = function()
-    vim.keymap.set("n", "<LEADER>lT", "<CMD>Trouble diagnostics toggle<CR>", { silent = true, desc = "Trouble" })
-  end,
 })

--- a/home/dotfiles/lvim/lvim/lua/user-plugins/utils/yankring-vim.lua
+++ b/home/dotfiles/lvim/lvim/lua/user-plugins/utils/yankring-vim.lua
@@ -5,7 +5,7 @@ table.insert(lvim.plugins, {
   init = function()
     vim.g.yankring_history_dir = os.getenv("XDG_STATE_HOME") .. "/yankring"
 
-    vim.keymap.set("n", "<LEADER>yh", "<CMD>YRShow<CR>", { silent = true, desc = "YankRing show" })
+    vim.keymap.set("n", "<LEADER>yh", "<CMD>YRShow<CR>", { silent = true, desc = "YankRing Show" })
     vim.g.yankring_replace_n_pkey = "<C-y><C-p>"
     vim.g.yankring_replace_n_nkey = "<C-y><C-n>"
   end,


### PR DESCRIPTION
- reorganize LSP menu items in `which-key.nvim` configuration
- remove redundant `Trouble.nvim` keymaps and standardize command case
- standardize command descriptions to use capital letters
- fix `CR/ESC` key notation to be consistent