### PR TITLE
🐞fix: replace bit library with native bitwise operators

### DIFF
--- a/home/dotfiles/sketchybar/sketchybar/colors.lua
+++ b/home/dotfiles/sketchybar/sketchybar/colors.lua
@@ -25,7 +25,6 @@ return {
     if alpha > 1.0 or alpha < 0.0 then
       return color
     end
-    local bit = require("bit")
-    return bit.bor(bit.band(color, 0x00ffffff), bit.lshift(math.floor(alpha * 255.0), 24))
+    return (color & 0x00ffffff) | (math.floor(alpha * 255.0) << 24)
   end,
 }


### PR DESCRIPTION
- replace deprecated bit library functions with native bitwise operators in Lua 5.3+
- remove unnecessary bit library requirement
- improve code readability with more concise syntax