### PR TITLE
🔨refactor: change terminal launch keybindings in WM

### DIFF
--- a/home/dotfiles/glzr/glzr/glazewm/config.yaml
+++ b/home/dotfiles/glzr/glzr/glazewm/config.yaml
@@ -173,7 +173,7 @@ keybindings:
   # `shell-exec %ProgramFiles%/Git/git-bash.exe` to start Windows
   # Terminal and Git Bash respectively.
   - commands: ["shell-exec wezterm-gui.exe"]
-    bindings: ["alt+enter"]
+    bindings: ["ctrl+shift+alt+t"]
 
   # # focus the workspace that last had focus.
   # - commands: ["focus --recent-workspace"]

--- a/home/dotfiles/hypr/hypr/hyprland.conf
+++ b/home/dotfiles/hypr/hypr/hyprland.conf
@@ -88,7 +88,7 @@ $mainMod = ALT
 # functions
 bind = SUPER, Q, killactive
 bind = SUPER, E, exec, dolphin
-bind = SUPER, RETURN, exec, wezterm
+bind = SUPER, T, exec, wezterm
 bind = SUPER SHIFT, S, exec, hyprshot -m region --clipboard-only
 bind = $mainMod, Space, exec, wofi --show drun
 bind = $mainMod, S, togglesplit


### PR DESCRIPTION
- change `GlazeWM` terminal launch key from `alt+enter` to `ctrl+shift+alt+t`
- change `Hyprland` terminal launch key from `super+return` to `super+t`