### PR TITLE
🔨refactor(lunarvim): improve `lunarvim` configuration settings

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/config/options.lua
+++ b/home/dotfiles/lvim/lvim/lua/config/options.lua
@@ -1,7 +1,7 @@
 -- options
 -- encoding
 vim.opt.encoding = "utf-8"
-vim.fileencoding = "utf-8"
+vim.opt.fileencoding = "utf-8"
 vim.scriptencoding = "utf-8"
 -- lang
 vim.opt.helplang = "ja"
@@ -15,7 +15,7 @@ vim.opt.updatetime = 200
 vim.opt.number = true
 -- highlight current line
 vim.opt.cursorline = true
--- cuesor position
+-- cursor position
 vim.opt.ruler = true
 -- sign coolumn
 vim.opt.signcolumn = "yes"
@@ -35,7 +35,6 @@ vim.opt.hlsearch = true
 vim.opt.ignorecase = true
 vim.opt.smartcase = true
 vim.opt.incsearch = true
-vim.cmd([[set noignorecase]])
 vim.cmd([[set nowrapscan]])
 -- command history
 vim.opt.history = 1000
@@ -55,10 +54,13 @@ vim.opt.splitright = true
 vim.opt.shell = os.getenv("SHELL")
 -- syntax highlight
 vim.opt.syntax = "enable"
--- clipboaed
+-- clipboard
 vim.opt.clipboard:append("unnamedplus")
 -- ignore auto format
 vim.api.nvim_create_user_command("W", "noautocmd w", {})
 vim.api.nvim_create_user_command("Wq", "noautocmd wq", {})
 -- disable line move with h and l
 vim.opt.whichwrap = vim.opt.whichwrap - "h" - "l"
+-- display
+vim.opt.cmdheight = 0
+vim.opt.display = "lastline"


### PR DESCRIPTION
- fix typos in comments (`cuesor` -> `cursor`, `clipboaed` -> `clipboard`)
- fix `vim.fileencoding` setting to use `vim.opt` API
- remove redundant `noignorecase` setting
- add display settings for better UI experience:
  - set `cmdheight` to `0` for more screen space
  - set `display` to `lastline` to show long lines better