### PR TITLE
👷chore(cli): switch `q/Q` keybind in `yazi`

### DIFF
--- a/home/dotfiles/yazi/yazi/keymap.toml
+++ b/home/dotfiles/yazi/yazi/keymap.toml
@@ -12,10 +12,10 @@ keymap = [
     "<C-[>",
   ], run = "escape", desc = "Exit visual mode, clear selected, or cancel search" },
   { on = [
-    "q",
+    "Q",
   ], run = "quit", desc = "Quit the process" },
   { on = [
-    "Q",
+    "q",
   ], run = "quit --no-cwd-file", desc = "Quit the process without outputting cwd-file" },
   { on = [
     "<C-c>",


### PR DESCRIPTION
- switch keybinding of `q` and `Q` in `yazi` configuration for better  usability