### PR TITLE
👷chore(zsh): add `zz` alias for `z -` (zoxide)

### DIFF
--- a/home/dotfiles/zsh/zsh/.zshrc
+++ b/home/dotfiles/zsh/zsh/.zshrc
@@ -51,6 +51,7 @@ alias st="systemctl-tui"
 alias tree="$(which eza) --tree"
 alias trl="trello-tui -board yanoBoard"
 alias zmv="noglob zmv -W"
+alias zz="z -"
 # make state directory
 if [[ ! -d "$XDG_STATE_HOME/zsh" ]]; then
 	mkdir -p "$XDG_STATE_HOME/zsh"


### PR DESCRIPTION
- add `zz` alias for `z -` command in zsh to quickly jump to previous  directory