### PR TITLE
👷chore(win): enable cursor jump on window focus in `GlazeWM`

### DIFF
--- a/home/dotfiles/glzr/glzr/glazewm/config.yaml
+++ b/home/dotfiles/glzr/glzr/glazewm/config.yaml
@@ -5,7 +5,7 @@ general:
   focus_follows_cursor: true
   toggle_workspace_on_refocus: true
   cursor_jump:
-    enabled: false
+    enabled: true
     trigger: "window_focus"
   hide_method: "cloak"
   show_all_in_taskbar: false


### PR DESCRIPTION
- enable `cursor_jump` for better cursor control when focusing window
- this setting automatically moves the cursor to the focused window
- aims to improve window management workflow efficiency