### PR TITLE
✨feat(zsh): add `per-directory-history` plugin for zsh

### DIFF
--- a/home/dotfiles/sheldon/sheldon/plugins.toml
+++ b/home/dotfiles/sheldon/sheldon/plugins.toml
@@ -37,6 +37,10 @@ apply = ["defer"]
 github = "zsh-users/zsh-completions"
 apply = ["defer"]
 
+[plugins.per-directory-history]
+github = "jimhester/per-directory-history"
+apply = ["defer"]
+
 [plugins.zsh-you-should-use]
 github = "MichaelAquilina/zsh-you-should-use"
 apply = ["defer"]

--- a/home/dotfiles/zsh/zsh/.zshenv
+++ b/home/dotfiles/zsh/zsh/.zshenv
@@ -108,3 +108,6 @@ if [[ "$OS" = "Darwin" ]]; then
 fi
 # yazi
 export YAZI_CONFIG_HOME=$XDG_CONFIG_HOME/yazi-alt
+# per-directory-history
+export HISTORY_BASE=$XDG_STATE_HOME/zsh/per-directory-history
+export PER_DIRECTORY_HISTORY_TOGGLE="^h"


### PR DESCRIPTION
- add `per-directory-history` plugin in `sheldon/plugins.toml`
- configure environment variables in `.zshenv` for the plugin
  - set history base directory to `$XDG_STATE_HOME/zsh/per-directory-history`
  - set toggle key binding to `Ctrl-h`