### PR TITLE
🐞fix(lunarvim): remove custom selection function from Commit command

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/user-plugins/utils/ai/copilotchat-nvim.lua
+++ b/home/dotfiles/lvim/lvim/lua/user-plugins/utils/ai/copilotchat-nvim.lua
@@ -175,9 +175,6 @@ body:
 <本文>
 ```
 ]],
-        selection = function(source)
-          return require("CopilotChat.select").gitdiff(source, true)
-        end,
       },
     },
     model = "claude-3.5-sonnet",


### PR DESCRIPTION
- remove dedicated selection function from Commit command prompt
- use common selection function defined in the plugin options instead
- `select.gitdiff()` was removed in [here](https://github.com/CopilotC-Nvim/CopilotChat.nvim/commit/149f7bf303638f2049281248a8a1d886452ed684).