### PR TITLE
💄style(lunarivm): remove custom heading icons from `render-markdown.n…

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/user-plugins/appearance/render-markdown-nvim.lua
+++ b/home/dotfiles/lvim/lvim/lua/user-plugins/appearance/render-markdown-nvim.lua
@@ -6,7 +6,6 @@ table.insert(lvim.plugins, {
     require("render-markdown").setup({
       heading = {
         position = "inline",
-        icons = { "󰼏  ", "󰎨  " },
       },
       code = {
         left_pad = 2,


### PR DESCRIPTION
- remove unnecessary custom heading icons from `render-markdown.nvim` config
- let plugin use its default heading icons for better maintainability