### PR TITLE
✨feat(lunarvim): disable `python` tools in `avante.nvim` Copilot inte…

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/user-plugins/utils/ai/avante-nvim.lua
+++ b/home/dotfiles/lvim/lvim/lua/user-plugins/utils/ai/avante-nvim.lua
@@ -46,6 +46,9 @@ table.insert(lvim.plugins, {
     provider = "copilot",
     copilot = {
       model = "claude-3.7-sonnet",
+      disabled_tools = {
+        "python",
+      },
     },
     -- auto_suggestions_provider = "copilot",
     behaviour = {


### PR DESCRIPTION
- add `python` to `disabled_tools` configuration in `avante.nvim` setup
- this prevents `python-specific` assistant tools from activating