### PR TITLE
✨feat: add in-and-out.nvim for quick character navigation

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/user-plugins/utils/clever-f-vim.lua
+++ b/home/dotfiles/lvim/lvim/lua/user-plugins/utils/clever-f-vim.lua
@@ -1,0 +1,5 @@
+-- extends f, F, t, T commands
+table.insert(lvim.plugins, {
+  "rhysd/clever-f.vim",
+  event = { "BufRead", "BufEnter" },
+})

--- a/home/dotfiles/lvim/lvim/lua/user-plugins/utils/in-and-out-nvim.lua
+++ b/home/dotfiles/lvim/lvim/lua/user-plugins/utils/in-and-out-nvim.lua
@@ -1,0 +1,10 @@
+-- quickly navigate in and out of surrounding character
+table.insert(lvim.plugins, {
+  "ysmb-wtsg/in-and-out.nvim",
+  event = { "BufRead", "BufEnter" },
+  init = function()
+    vim.keymap.set("i", "<C-l>", function()
+      require("in-and-out").in_and_out()
+    end, { desc = "In and Out" })
+  end,
+})

--- a/home/dotfiles/lvim/lvim/lua/user-plugins/utils/nvim-surround.lua
+++ b/home/dotfiles/lvim/lvim/lua/user-plugins/utils/nvim-surround.lua
@@ -1,0 +1,10 @@
+-- surround selection with brackets, quotes, etc.
+table.insert(lvim.plugins, {
+  "kylechui/nvim-surround",
+  event = { "BufRead", "BufEnter" },
+  config = function()
+    require("nvim-surround").setup({
+      -- Configuration here, or leave empty to use defaults
+    })
+  end,
+})

--- a/home/dotfiles/lvim/lvim/lua/user-plugins/utils/quick-scope.lua
+++ b/home/dotfiles/lvim/lvim/lua/user-plugins/utils/quick-scope.lua
@@ -1,0 +1,5 @@
+-- an always-on highlight for a unique character in every word on a line to help you use f, F and family.
+table.insert(lvim.plugins, {
+  "unblevable/quick-scope",
+  event = { "BufRead", "BufEnter" },
+})


### PR DESCRIPTION
- add `in-and-out.nvim` for quick character navigation
- add `nvim-surround` plugin for text surrounding operations

- add `clever-f.vim` to extend `f,F,t,T` commands

- add `quick-scope` plugin for improved `f/F` navigation