### PR TITLE
🐞fix: add `golangci-lint` to `ensure_installed` tools list

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/language/tools/linter.lua
+++ b/home/dotfiles/lvim/lvim/lua/language/tools/linter.lua
@@ -12,6 +12,7 @@ table.insert(lvim.plugins, {
         -- common
         "proselint",
         -- languages
+        "golangci-lint", -- go (configuration in ../../../after/ftplugin/go.lua)
         "shellcheck", -- shell
       },
     })


### PR DESCRIPTION
- add `golangci-lint` for Go language linting in the `mason-tool-installer` configuration