### PR TITLE
🐞fix: change `in-and-out.nvim` plugin lazy loading trigger

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/user/editor/navigation/in-and-out-nvim.lua
+++ b/home/dotfiles/lvim/lvim/lua/user/editor/navigation/in-and-out-nvim.lua
@@ -1,7 +1,7 @@
 -- quickly navigate in and out of surrounding character
 table.insert(lvim.plugins, {
   "ysmb-wtsg/in-and-out.nvim",
-  keys = { "<C-l>" },
+  event = "InsertEnter",
   init = function()
     vim.keymap.set("i", "<C-l>", function()
       require("in-and-out").in_and_out()


### PR DESCRIPTION
- changed plugin loading trigger from key-based to event-based
- plugin now loads on `InsertEnter` instead of waiting for `<C-l>` key
- this ensures plugin is preloaded when entering insert mode
- may provide more consistent experience with less delay on key press