### PR TITLE
✨feat: add custom config for `typos_lsp`

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/language/config/typos.toml
+++ b/home/dotfiles/lvim/lvim/lua/language/config/typos.toml
@@ -1,0 +1,2 @@
+[default.extend-words]
+noice = "noice"

--- a/home/dotfiles/lvim/lvim/lua/language/lsp.lua
+++ b/home/dotfiles/lvim/lvim/lua/language/lsp.lua
@@ -56,4 +56,8 @@ vim.list_extend(lvim.lsp.automatic_configuration.skipped_filetypes, {
 -- common
 require("lvim.lsp.manager").setup("ast_grep") -- AST
 require("lvim.lsp.manager").setup("diagnosticls") -- diagnostic
-require("lvim.lsp.manager").setup("typos_lsp") -- typos
+require("lvim.lsp.manager").setup("typos_lsp", { -- typos
+  init_options = {
+    config = os.getenv("XDG_CONFIG_HOME") .. "/lvim/lua/language/config/typos.toml",
+  },
+})


### PR DESCRIPTION
- create `typos.toml` configuration file to ignore specific words
- configure `typos_lsp` to use the custom configuration file
- add "noice" to the list of allowed words to prevent false positives