### PR TITLE
🔨refactor(lunarvim): separate `nvim-notify` from `noice` configuration

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/plugins/core/which-key.lua
+++ b/home/dotfiles/lvim/lvim/lua/plugins/core/which-key.lua
@@ -73,6 +73,8 @@ table.insert(lvim.builtin.which_key.mappings["l"], {
   -- TodoLocList
   T = { "<CMD>TodoLocList<CR>", "TodoLocList" },
 })
+-- noice
+lvim.builtin.which_key.mappings["n"] = { "<CMD>NoiceTelescope<CR>", "NoiceTelescope" }
 -- oil filer
 lvim.builtin.which_key.mappings["o"] = { "<CMD>Oil<CR>", "Oil" }
 -- search

--- a/home/dotfiles/lvim/lvim/lua/plugins/user/ui/components/noice-nvim.lua
+++ b/home/dotfiles/lvim/lvim/lua/plugins/user/ui/components/noice-nvim.lua
@@ -7,25 +7,6 @@ table.insert(lvim.plugins, {
     "rcarriga/nvim-notify",
   },
   config = function()
-    vim.notify = require("notify")
-    require("notify").setup({
-      background_colour = "#000000",
-      stages = "fade",
-      icons = {
-        ERROR = "",
-        WARN = "",
-        INFO = "",
-        DEBUG = "",
-        TRACE = "✎",
-      },
-      colors = {
-        error = "#e67e80", -- Everforest red
-        warn = "#dbbc7f", -- Everforest yellow
-        info = "#83c092", -- Everforest sage green
-        debug = "#7fbbb3", -- Everforest blue
-        trace = "#d3c6aa", -- Everforest foreground
-      },
-    })
     require("noice").setup({
       cmdline = {
         enabled = true, -- enables the Noice cmdline UI

--- a/home/dotfiles/lvim/lvim/lua/plugins/user/ui/components/nvim-notify.lua
+++ b/home/dotfiles/lvim/lvim/lua/plugins/user/ui/components/nvim-notify.lua
@@ -1,0 +1,21 @@
+-- notification
+table.insert(lvim.plugins, {
+  "rcarriga/nvim-notify",
+  event = "UIEnter",
+  config = function()
+    vim.notify = require("notify")
+    require("notify").setup({
+      fps = 60,
+      colors = {
+        error = "#e67e80", -- Everforest red
+        warn = "#dbbc7f", -- Everforest yellow
+        info = "#83c092", -- Everforest sage green
+        debug = "#7fbbb3", -- Everforest blue
+        trace = "#d3c6aa", -- Everforest foreground
+      },
+      render = "compact",
+      timeout = 500,
+      top_down = false,
+    })
+  end,
+})


### PR DESCRIPTION
- add dedicated keybinding for `NoiceTelescope` under `n` key
- extract `nvim-notify` configuration into separate module
- update `nvim-notify` settings with optimized parameters:
  - set fps to 60 for smoother animations
  - use compact render style
  - set 500ms timeout
  - display notifications bottom-up