### PR TITLE
🐞fix(lunarvim): centralize mason tool installer configurations

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/language/tools/actions.lua
+++ b/home/dotfiles/lvim/lvim/lua/language/tools/actions.lua
@@ -1,23 +1,8 @@
 -- action config
--- automatically install missing tools
-table.insert(lvim.plugins, {
-  "WhoIsSethDaniel/mason-tool-installer.nvim",
-  dependencies = {
-    "williamboman/mason.nvim",
-    "williamboman/mason-lspconfig.nvim",
-  },
-  config = function()
-    require("mason-tool-installer").setup({
-      ensure_installed = {
-        -- common
-        "proselint",
-      },
-    })
-  end,
-})
 require("lvim.lsp.null-ls.code_actions").setup({
   -- common
   {
-    name = "proselint",
+    name = "proselint", -- prose
+    filetypes = { "text", "markdown" },
   },
 })

--- a/home/dotfiles/lvim/lvim/lua/language/tools/formatters.lua
+++ b/home/dotfiles/lvim/lvim/lua/language/tools/formatters.lua
@@ -1,24 +1,4 @@
 -- formatter config
--- automatically install missing formatter
-table.insert(lvim.plugins, {
-  "WhoIsSethDaniel/mason-tool-installer.nvim",
-  dependencies = {
-    "williamboman/mason.nvim",
-    "williamboman/mason-lspconfig.nvim",
-  },
-  config = function()
-    require("mason-tool-installer").setup({
-      ensure_installed = {
-        -- web
-        "prettier",
-        -- languages
-        "nixfmt", -- nix
-        "shfmt", -- shell
-        "stylua", -- lua
-      },
-    })
-  end,
-})
 require("lvim.lsp.null-ls.formatters").setup({
   -- web
   {

--- a/home/dotfiles/lvim/lvim/lua/language/tools/linters.lua
+++ b/home/dotfiles/lvim/lvim/lua/language/tools/linters.lua
@@ -1,23 +1,4 @@
 -- linter config
--- automatically install missing linters
-table.insert(lvim.plugins, {
-  "WhoIsSethDaniel/mason-tool-installer.nvim",
-  dependencies = {
-    "williamboman/mason.nvim",
-    "williamboman/mason-lspconfig.nvim",
-  },
-  config = function()
-    require("mason-tool-installer").setup({
-      ensure_installed = {
-        -- common
-        "proselint",
-        -- languages
-        "golangci-lint", -- go
-        "shellcheck", -- shell
-      },
-    })
-  end,
-})
 require("lvim.lsp.null-ls.linters").setup({
   -- common
   {

--- a/home/dotfiles/lvim/lvim/lua/language/tools/tools.lua
+++ b/home/dotfiles/lvim/lvim/lua/language/tools/tools.lua
@@ -1,0 +1,31 @@
+-- define tools to be installed with mason
+-- automatically install missing tools
+table.insert(lvim.plugins, {
+  "WhoIsSethDaniel/mason-tool-installer.nvim",
+  dependencies = {
+    "williamboman/mason.nvim",
+    "williamboman/mason-lspconfig.nvim",
+  },
+  config = function()
+    require("mason-tool-installer").setup({
+      ensure_installed = {
+        -- actions
+        -- common
+        "proselint",
+
+        --formatters
+        -- web
+        "prettier",
+        -- languages
+        "nixfmt", -- nix
+        "shfmt", -- shell
+        "stylua", -- lua
+
+        -- linters
+        -- languages
+        "golangci-lint", -- go
+        "shellcheck", -- shell
+      },
+    })
+  end,
+})


### PR DESCRIPTION
- move all tool installation settings into a single dedicated file
- consolidate duplicate `mason-tool-installer` configurations from actions, formatters, and linters modules
- add filetypes specification for `proselint` (text, markdown)
- improve code organization and maintainability by removing redundancy