### PR TITLE
👷chore: remove `gum` dependency and improve automation

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -88,9 +88,9 @@ description = "yanoMac update brew pkglist"
 script = '''
 ./scripts/util/updateBrewPkglist.sh
 '''
-## restart window manager services
-[tasks."darwin.restart.windowmanager"]
-description = "yanoMac restart window manager services"
+## restart services
+[tasks."darwin.restart.services"]
+description = "yanoMac restart services"
 script = '''
 ./scripts/util/restartServices.sh
 '''

--- a/modules/programs/shell.nix
+++ b/modules/programs/shell.nix
@@ -12,7 +12,6 @@
       ghq
       git
       gnumake
-      gum
       lf
       libiconv
       lsof

--- a/scripts/install/darwin.sh
+++ b/scripts/install/darwin.sh
@@ -1,27 +1,21 @@
 #!/usr/bin/env bash
 # yanosea darwin nix install packages script
-# confirm install
-if gum confirm "Do you install packages for darwin?"; then
-	# install new packages
-	# clone ghq repos
-	echo -e $'\n\e[33;1mclone ghq packages!\e[m'
-	xargs -I arg ghq get arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/ghq/pkglist.txt
-	# install go packages
-	echo -e $'\n\e[33;1minstall go packages!\e[m'
-	xargs -I arg go install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/go/pkglist.txt
-	# install brew packages
-	echo -e $'\n\e[33;1minstall brew packages!\e[m'
-	xargs -I arg brew install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/brew/pkglist.txt
-	# apply nix
-	echo -e $'\n\e[33;1mapply nix darwin!\e[m'
-	sudo rm -r $HOME/.nix-defexpr && sudo nix-channel --update
-	cargo make darwin.apply.system
-	# apply home-manager
-	echo -e $'\n\e[33;1mapply home-manager!\e[m'
-	cargo make darwin.apply.home
-	# done!
-	echo -e $'\n\e[32;1minstall complete!\e[m'
-else
-	# initialize cancelled
-	echo -e $'\n\e[31;1minitialize cancelled...\e[m'
-fi
+# install new packages
+# clone ghq repos
+echo -e $'\n\e[33;1mclone ghq packages!\e[m'
+xargs -I arg ghq get arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/ghq/pkglist.txt
+# install go packages
+echo -e $'\n\e[33;1minstall go packages!\e[m'
+xargs -I arg go install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/go/pkglist.txt
+# install brew packages
+echo -e $'\n\e[33;1minstall brew packages!\e[m'
+xargs -I arg brew install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/brew/pkglist.txt
+# apply nix
+echo -e $'\n\e[33;1mapply nix darwin!\e[m'
+sudo rm -r $HOME/.nix-defexpr && sudo nix-channel --update
+cargo make darwin.apply.system
+# apply home-manager
+echo -e $'\n\e[33;1mapply home-manager!\e[m'
+cargo make darwin.apply.home
+# done!
+echo -e $'\n\e[32;1minstall complete!\e[m'

--- a/scripts/install/nixos.sh
+++ b/scripts/install/nixos.sh
@@ -1,23 +1,17 @@
 #!/usr/bin/env bash
 # yanosea nixos install packages script
-# confirm install
-if gum confirm "Do you install packages for NixOS?"; then
-	# install new packages
-	# clone ghq repos
-	echo -e $'\n\e[33;1mclone ghq packages!\e[m'
-	xargs -I arg ghq get arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/ghq/pkglist.txt
-	# install go packages
-	echo -e $'\n\e[33;1minstall go packages!\e[m'
-	xargs -I arg go install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/go/pkglist.txt
-	# apply nix
-	echo -e $'\n\e[33;1mapply nixos!\e[m'
-	cargo make nix.apply.system
-	# apply home-manager
-	echo -e $'\n\e[33;1mapply home-manager!\e[m'
-	cargo make nix.apply.home
-	# done!
-	echo -e $'\n\e[32;1minstall complete!\e[m'
-else
-	# initialize cancelled
-	echo -e $'\n\e[31;1minstall cancelled...\e[m'
-fi
+# install new packages
+# clone ghq repos
+echo -e $'\n\e[33;1mclone ghq packages!\e[m'
+xargs -I arg ghq get arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/ghq/pkglist.txt
+# install go packages
+echo -e $'\n\e[33;1minstall go packages!\e[m'
+xargs -I arg go install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/go/pkglist.txt
+# apply nix
+echo -e $'\n\e[33;1mapply nixos!\e[m'
+cargo make nix.apply.system
+# apply home-manager
+echo -e $'\n\e[33;1mapply home-manager!\e[m'
+cargo make nix.apply.home
+# done!
+echo -e $'\n\e[32;1minstall complete!\e[m'

--- a/scripts/install/nixos_wsl.sh
+++ b/scripts/install/nixos_wsl.sh
@@ -1,23 +1,17 @@
 #!/usr/bin/env bash
 # yanosea nixos wsl install packages script
-# confirm install
-if gum confirm "Do you install packages for NixOS WSL?"; then
-	# install new packages
-	# clone ghq repos
-	echo -e $'\n\e[33;1mclone ghq packages!\e[m'
-	xargs -I arg ghq get arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/ghq/pkglist.txt
-	# install go packages
-	echo -e $'\n\e[33;1minstall go packages!\e[m'
-	xargs -I arg go install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/go/pkglist.txt
-	# apply nix
-	echo -e $'\n\e[33;1mapply nixos wsl!\e[m'
-	cargo make wsl.apply.system
-	# apply home-manager
-	echo -e $'\n\e[33;1mapply home-manager!\e[m'
-	cargo make wsl.apply.home
-	# done!
-	echo -e $'\n\e[32;1minstall complete!\e[m'
-else
-	# initialize cancelled
-	echo -e $'\n\e[31;1minstall cancelled...\e[m'
-fi
+# install new packages
+# clone ghq repos
+echo -e $'\n\e[33;1mclone ghq packages!\e[m'
+xargs -I arg ghq get arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/ghq/pkglist.txt
+# install go packages
+echo -e $'\n\e[33;1minstall go packages!\e[m'
+xargs -I arg go install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/go/pkglist.txt
+# apply nix
+echo -e $'\n\e[33;1mapply nixos wsl!\e[m'
+cargo make wsl.apply.system
+# apply home-manager
+echo -e $'\n\e[33;1mapply home-manager!\e[m'
+cargo make wsl.apply.home
+# done!
+echo -e $'\n\e[32;1minstall complete!\e[m'

--- a/scripts/install/windows.ps1
+++ b/scripts/install/windows.ps1
@@ -1,16 +1,12 @@
 # yanosea windows env install packages script
-& gum confirm "Do you install packages for windows?"
-if ($LASTEXITCODE -eq 0) {
-    # clone ghq repose
-    Write-Host "`nclone ghq repos!" -ForegroundColor Yellow
-    $filePath = "$HOME\ghq\github.com\yanosea\yanoNixFiles\pkglist\ghq\pkglist.txt"
-    Get-Content -Path $filePath | ForEach-Object {
-        & ghq get $_
-    }
-    # install winget packages
-    Write-Host "`ninstall winget packages!" -ForegroundColor Yellow
-    winget import "$HOME\ghq\github.com\yanosea\yanoNixFiles\pkglist\winget\pkglist.json"
-} else {
-    # install cancelled
-    Write-Host "`ninstall cancelled..." -ForegroundColor Red
+# clone ghq repose
+Write-Host "`nclone ghq repos!" -ForegroundColor Yellow
+$filePath = "$HOME\ghq\github.com\yanosea\yanoNixFiles\pkglist\ghq\pkglist.txt"
+Get-Content -Path $filePath | ForEach-Object {
+    & ghq get $_
 }
+# install winget packages
+Write-Host "`ninstall winget packages!" -ForegroundColor Yellow
+winget import "$HOME\ghq\github.com\yanosea\yanoNixFiles\pkglist\winget\pkglist.json"
+# done!
+Write-Host "`ndone!" -ForegroundColor Green

--- a/scripts/update/darwin.sh
+++ b/scripts/update/darwin.sh
@@ -1,45 +1,39 @@
 #!/usr/bin/env bash
 # yanosea darwin nix env update script
-# confirm update
-if gum confirm "Do you update darwin nix env?"; then
-	# sync ghq repos
-	echo -e $'\n\e[33;1msync ghq repos!\e[m'
-	ghq list | ghq get --update
-	# update go packages
-	echo -e $'\n\e[33;1mupdate go packages!\e[m'
-	gup update
-	# update zsh plugins
-	echo -e $'\n\e[33;1mupdate zsh plugins!\e[m'
-	sheldon lock --update
-	# update brew packages
-	echo -e $'\n\e[33;1mupdate brew packages!\e[m'
-	brew update
-	brew upgrade
-	brew cleanup
-	brew doctor
-	# install new packages
-	# clone ghq repos
-	echo -e $'\n\e[33;1mclone ghq packages!\e[m'
-	xargs -I arg ghq get arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/ghq/pkglist.txt
-	# install go packages
-	echo -e $'\n\e[33;1minstall go packages!\e[m'
-	xargs -I arg go install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/go/pkglist.txt
-	# install brew packages
-	echo -e $'\n\e[33;1minstall brew packages!\e[m'
-	xargs -I arg brew install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/brew/pkglist.txt
-	# update nix
-	echo -e $'\n\e[33;1mupdate nix!\e[m'
-	nix-env -u
-	# apply nix
-	echo -e $'\n\e[33;1mapply nix darwin!\e[m'
-	sudo rm -r $HOME/.nix-defexpr && sudo nix-channel --update
-	cargo make darwin.apply.system
-	# apply home-manager
-	echo -e $'\n\e[33;1mapply home-manager!\e[m'
-	cargo make darwin.apply.home
-	# done!
-	echo -e $'\n\e[32;1mupdate complete!\e[m'
-else
-	# initialize cancelled
-	echo -e $'\n\e[31;1minitialize cancelled...\e[m'
-fi
+# sync ghq repos
+echo -e $'\n\e[33;1msync ghq repos!\e[m'
+ghq list | ghq get --update
+# update go packages
+echo -e $'\n\e[33;1mupdate go packages!\e[m'
+gup update
+# update zsh plugins
+echo -e $'\n\e[33;1mupdate zsh plugins!\e[m'
+sheldon lock --update
+# update brew packages
+echo -e $'\n\e[33;1mupdate brew packages!\e[m'
+brew update
+brew upgrade
+brew cleanup
+brew doctor
+# install new packages
+# clone ghq repos
+echo -e $'\n\e[33;1mclone ghq packages!\e[m'
+xargs -I arg ghq get arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/ghq/pkglist.txt
+# install go packages
+echo -e $'\n\e[33;1minstall go packages!\e[m'
+xargs -I arg go install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/go/pkglist.txt
+# install brew packages
+echo -e $'\n\e[33;1minstall brew packages!\e[m'
+xargs -I arg brew install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/brew/pkglist.txt
+# update nix
+echo -e $'\n\e[33;1mupdate nix!\e[m'
+nix-env -u
+# apply nix
+echo -e $'\n\e[33;1mapply nix darwin!\e[m'
+sudo rm -r $HOME/.nix-defexpr && sudo nix-channel --update
+cargo make darwin.apply.system
+# apply home-manager
+echo -e $'\n\e[33;1mapply home-manager!\e[m'
+cargo make darwin.apply.home
+# done!
+echo -e $'\n\e[32;1mupdate complete!\e[m'

--- a/scripts/update/nixos.sh
+++ b/scripts/update/nixos.sh
@@ -1,35 +1,29 @@
 #!/usr/bin/env bash
 # yanosea nixos env update script
-# confirm update
-if gum confirm "Do you update nixos env?"; then
-	# sync ghq repos
-	echo -e $'\n\e[33;1msync ghq repos!\e[m'
-	ghq list | ghq get --update
-	# update go packages
-	echo -e $'\n\e[33;1mupdate go packages!\e[m'
-	gup update
-	# update zsh plugins
-	echo -e $'\n\e[33;1mupdate zsh plugins!\e[m'
-	sheldon lock --update
-	# install new packages
-	# clone ghq repos
-	echo -e $'\n\e[33;1mclone ghq packages!\e[m'
-	xargs -I arg ghq get arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/ghq/pkglist.txt
-	# install go packages
-	echo -e $'\n\e[33;1minstall go packages!\e[m'
-	xargs -I arg go install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/go/pkglist.txt
-	# update nix
-	echo -e $'\n\e[33;1mupdate nix!\e[m'
-	nix-env -u
-	# apply nix
-	echo -e $'\n\e[33;1mapply nixos!\e[m'
-	cargo make nix.apply.system
-	# apply home-manager
-	echo -e $'\n\e[33;1mapply home-manager!\e[m'
-	cargo make nix.apply.home
-	# done!
-	echo -e $'\n\e[32;1mupdate complete!\e[m'
-else
-	# initialize cancelled
-	echo -e $'\n\e[31;1mupdate cancelled...\e[m'
-fi
+# sync ghq repos
+echo -e $'\n\e[33;1msync ghq repos!\e[m'
+ghq list | ghq get --update
+# update go packages
+echo -e $'\n\e[33;1mupdate go packages!\e[m'
+gup update
+# update zsh plugins
+echo -e $'\n\e[33;1mupdate zsh plugins!\e[m'
+sheldon lock --update
+# install new packages
+# clone ghq repos
+echo -e $'\n\e[33;1mclone ghq packages!\e[m'
+xargs -I arg ghq get arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/ghq/pkglist.txt
+# install go packages
+echo -e $'\n\e[33;1minstall go packages!\e[m'
+xargs -I arg go install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/go/pkglist.txt
+# update nix
+echo -e $'\n\e[33;1mupdate nix!\e[m'
+nix-env -u
+# apply nix
+echo -e $'\n\e[33;1mapply nixos!\e[m'
+cargo make nix.apply.system
+# apply home-manager
+echo -e $'\n\e[33;1mapply home-manager!\e[m'
+cargo make nix.apply.home
+# done!
+echo -e $'\n\e[32;1mupdate complete!\e[m'

--- a/scripts/update/nixos_wsl.sh
+++ b/scripts/update/nixos_wsl.sh
@@ -1,35 +1,29 @@
 #!/usr/bin/env bash
 # yanosea nixos wsl env update script
-# confirm update
-if gum confirm "Do you update nixos env?"; then
-	# sync ghq repos
-	echo -e $'\n\e[33;1msync ghq repos!\e[m'
-	ghq list | ghq get --update
-	# update go packages
-	echo -e $'\n\e[33;1mupdate go packages!\e[m'
-	gup update
-	# update zsh plugins
-	echo -e $'\n\e[33;1mupdate zsh plugins!\e[m'
-	sheldon lock --update
-	# install new packages
-	# clone ghq repos
-	echo -e $'\n\e[33;1mclone ghq packages!\e[m'
-	xargs -I arg ghq get arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/ghq/pkglist.txt
-	# install go packages
-	echo -e $'\n\e[33;1minstall go packages!\e[m'
-	xargs -I arg go install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/go/pkglist.txt
-	# update nix
-	echo -e $'\n\e[33;1mupdate nix!\e[m'
-	nix-env -u
-	# apply nix
-	echo -e $'\n\e[33;1mapply nixos!\e[m'
-	cargo make wsl.apply.system
-	# apply home-manager
-	echo -e $'\n\e[33;1mapply home-manager!\e[m'
-	cargo make wsl.apply.home
-	# done!
-	echo -e $'\n\e[32;1mupdate complete!\e[m'
-else
-	# update cancelled
-	echo -e $'\n\e[31;1mupdate cancelled...\e[m'
-fi
+# sync ghq repos
+echo -e $'\n\e[33;1msync ghq repos!\e[m'
+ghq list | ghq get --update
+# update go packages
+echo -e $'\n\e[33;1mupdate go packages!\e[m'
+gup update
+# update zsh plugins
+echo -e $'\n\e[33;1mupdate zsh plugins!\e[m'
+sheldon lock --update
+# install new packages
+# clone ghq repos
+echo -e $'\n\e[33;1mclone ghq packages!\e[m'
+xargs -I arg ghq get arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/ghq/pkglist.txt
+# install go packages
+echo -e $'\n\e[33;1minstall go packages!\e[m'
+xargs -I arg go install arg <$HOME/ghq/github.com/yanosea/yanoNixFiles/pkglist/go/pkglist.txt
+# update nix
+echo -e $'\n\e[33;1mupdate nix!\e[m'
+nix-env -u
+# apply nix
+echo -e $'\n\e[33;1mapply nixos!\e[m'
+cargo make wsl.apply.system
+# apply home-manager
+echo -e $'\n\e[33;1mapply home-manager!\e[m'
+cargo make wsl.apply.home
+# done!
+echo -e $'\n\e[32;1mupdate complete!\e[m'

--- a/scripts/update/windows.ps1
+++ b/scripts/update/windows.ps1
@@ -1,33 +1,28 @@
 # yanosea windows env update packages script
-& gum confirm "Do you install packages for windows?"
-if ($LASTEXITCODE -eq 0) {
-    # sync ghq repos
-    Write-Host "`nsync ghq repos!" -ForegroundColor Yellow
-    ghq list | ghq get --update
-    # update winget packages
-    Write-Host "`nupdate winget packages!" -ForegroundColor Yellow
-    winget upgrade --silent --all
-    # update scoop
-    Write-Host "`nupdate scoop!" -ForegroundColor Yellow
-    scoop update
-    # clone ghq repose
-    Write-Host "`nclone ghq repos!" -ForegroundColor Yellow
-    $filePath = "$HOME\ghq\github.com\yanosea\yanoNixFiles\pkglist\ghq\pkglist.txt"
-    Get-Content -Path $filePath | ForEach-Object {
-        & ghq get $_
-    }
-    # install winget packages
-    Write-Host "`ninstall winget packages!" -ForegroundColor Yellow
-    winget import "$HOME\ghq\github.com\yanosea\yanoNixFiles\pkglist\winget\pkglist.json"
-    # export winget packages
-    Write-Host "`nexport winget packages!" -ForegroundColor Yellow
-    $exportPath = "$HOME\ghq\github.com\yanosea\yanoNixFiles\pkglist\winget\pkglist.json"
-    winget export -o $exportPath
-    # sort the exported packages
-    $sortedPackages = Get-Content -Path $exportPath | jq '.Sources[].Packages |= sort_by(.PackageIdentifier | ascii_downcase)'
-    $sortedPackages | Set-Content -Path $exportPath
-
-} else {
-    # update cancelled
-    Write-Host "`nupdate cancelled..." -ForegroundColor Red
+# sync ghq repos
+Write-Host "`nsync ghq repos!" -ForegroundColor Yellow
+ghq list | ghq get --update
+# update winget packages
+Write-Host "`nupdate winget packages!" -ForegroundColor Yellow
+winget upgrade --silent --all
+# update scoop
+Write-Host "`nupdate scoop!" -ForegroundColor Yellow
+scoop update
+# clone ghq repose
+Write-Host "`nclone ghq repos!" -ForegroundColor Yellow
+$filePath = "$HOME\ghq\github.com\yanosea\yanoNixFiles\pkglist\ghq\pkglist.txt"
+Get-Content -Path $filePath | ForEach-Object {
+    & ghq get $_
 }
+# install winget packages
+Write-Host "`ninstall winget packages!" -ForegroundColor Yellow
+winget import "$HOME\ghq\github.com\yanosea\yanoNixFiles\pkglist\winget\pkglist.json"
+# export winget packages
+Write-Host "`nexport winget packages!" -ForegroundColor Yellow
+$exportPath = "$HOME\ghq\github.com\yanosea\yanoNixFiles\pkglist\winget\pkglist.json"
+winget export -o $exportPath
+# sort the exported packages
+$sortedPackages = Get-Content -Path $exportPath | jq '.Sources[].Packages |= sort_by(.PackageIdentifier | ascii_downcase)'
+$sortedPackages | Set-Content -Path $exportPath
+# done!
+Write-Host "`ndone!" -ForegroundColor Green


### PR DESCRIPTION
- remove dependency on `gum` tool from all scripts
- delete confirmation prompts for more streamlined automation
- remove `gum` package from `shell.nix` dependencies
- rename task from `darwin.restart.windowmanager` to `darwin.restart.services` for better service management coverage