### PR TITLE
🔨refactor: update `avante.nvim` config and separate `img-clip`

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/plugins/user/tools/external/ai/avante_nvim.lua
+++ b/home/dotfiles/lvim/lvim/lua/plugins/user/tools/external/ai/avante_nvim.lua
@@ -2,48 +2,69 @@
 table.insert(lvim.plugins, {
   "yetone/avante.nvim",
   event = "VeryLazy",
+  version = false,
+  build = "make",
   dependencies = {
     "nvim-treesitter/nvim-treesitter",
     "stevearc/dressing.nvim",
     "nvim-lua/plenary.nvim",
     "MunifTanjim/nui.nvim",
     --- The below dependencies are optional,
-    { "echasnovski/mini.pick", lazy = true }, -- for file_selector provider mini.pick
     { "nvim-telescope/telescope.nvim", lazy = true }, -- for file_selector provider telescope
     { "hrsh7th/nvim-cmp", lazy = true }, -- autocompletion for avante commands and mentions
     { "ibhagwan/fzf-lua", lazy = true }, -- for file_selector provider fzf
     { "nvim-tree/nvim-web-devicons", lazy = true }, -- or echasnovski/mini.icons
     { "zbirenbaum/copilot.lua", lazy = true }, -- for providers='copilot'
-    {
-      -- support for image pasting
-      "HakonHarnes/img-clip.nvim",
-      lazy = true,
-      opts = {
-        -- recommended settings
-        default = {
-          embed_image_as_base64 = false,
-          prompt_for_file_name = false,
-          drag_and_drop = {
-            insert_mode = true,
+  },
+  opts = {
+    provider = "copilot",
+    mode = "agentic",
+    -- mode = "legacy",
+    auto_suggestions_provider = "copilot",
+    cursor_applying_provider = "copilot",
+    memory_summary_provider = "copilot",
+    copilot = {
+      endpoint = "https://api.githubcopilot.com",
+      model = "claude-3.7-sonnet",
+      proxy = nil, -- [protocol://]host[:port] Use this proxy
+      allow_insecure = true, -- Allow insecure server connections
+      timeout = 60000, -- Timeout in milliseconds
+      temperature = 0,
+      max_tokens = 50960,
+    },
+    system_prompt = require("plugins.user.tools.external.ai.system_prompt").SystemPrompt,
+    rag_service = {
+      enabled = false, -- Enables the rag service, requires OPENAI_API_KEY to be set
+      host_mount = os.getenv("HOME"), -- Host mount path for the rag service (docker will mount this path)
+      runner = "docker", -- The runner for the rag service, (can use docker, or nix)
+      provider = "openai", -- The provider to use for RAG service. eg: openai or ollama
+      llm_model = "", -- The LLM model to use for RAG service
+      embed_model = "", -- The embedding model to use for RAG service
+      endpoint = "https://api.openai.com/v1", -- The API endpoint for RAG service
+      docker_extra_args = "", -- Extra arguments to pass to the docker command
+    },
+    web_search_engine = {
+      provider = "tavily",
+      proxy = nil,
+      providers = {
+        tavily = {
+          api_key_name = "TAVILY_API_KEY",
+          extra_request_body = {
+            include_answer = "basic",
           },
-          -- required for Windows users
-          use_absolute_path = true,
+          format_response_body = function(body)
+            return body.answer, nil
+          end,
         },
       },
     },
-  },
-  build = "make",
-  version = false,
-  opts = {
-    provider = "copilot",
-    auto_suggestions_provider = "copilot",
-    copilot = {
-      model = "claude-3.7-sonnet",
-      disabled_tools = {
-        "python",
-      },
+    dual_boost = {
+      enabled = false,
+      first_provider = "copilot",
+      second_provider = "copilot",
+      prompt = "Based on the two reference outputs below, generate a response that incorporates elements from both but reflects your own judgment and unique perspective. Do not provide any explanation, just give the response directly. Reference Output 1: [{{provider1_output}}], Reference Output 2: [{{provider2_output}}]",
+      timeout = 60000, -- Timeout in milliseconds
     },
-    -- auto_suggestions_provider = "copilot",
     behaviour = {
       auto_focus_sidebar = false,
       auto_suggestions = true,
@@ -51,17 +72,38 @@ table.insert(lvim.plugins, {
       auto_set_highlight_group = true,
       auto_set_keymaps = true,
       auto_apply_diff_after_generation = false,
+      jump_result_buffer_on_finish = true,
       support_paste_from_clipboard = true,
       minimize_diff = true,
       enable_token_counting = true,
-      enable_cursor_planning_mode = false,
-      enable_claude_text_editor_tool_mode = false,
+      use_cwd_as_project_root = true,
+      auto_focus_on_diff_view = false,
     },
-    hints = { enabled = true },
+    history = {
+      max_tokens = 20480,
+      carried_entry_count = nil,
+      storage_path = vim.fn.stdpath("state") .. "/avante",
+      paste = {
+        extension = "png",
+        filename = "pasted-%Y-%m-%d-%H-%M-%S",
+      },
+    },
+    highlights = {
+      diff = {
+        current = nil,
+        incoming = nil,
+      },
+    },
+    img_paste = {
+      url_encode_path = true,
+      template = "\nimage: $FILE_PATH\n",
+    },
     windows = {
       position = "right",
+      fillchars = "eob: ",
       wrap = true,
       width = 32,
+      height = 32,
       sidebar_header = {
         enabled = true,
         align = "center",
@@ -82,14 +124,33 @@ table.insert(lvim.plugins, {
         focus_on_apply = "ours",
       },
     },
-    web_search_engine = {
-      provider = "tavily", -- tavily, serpapi, searchapi, google, kagi, brave, or searxng
-      proxy = nil, -- proxy support, e.g., http://127.0.0.1:7890
+    diff = {
+      autojump = false,
+      override_timeoutlen = 500,
     },
+    hints = {
+      enabled = true,
+    },
+    repo_map = {
+      ignore_patterns = { "%.git", "%.worktree", "__pycache__", "node_modules" }, -- ignore files matching these
+      negate_patterns = {}, -- negate ignore files matching these.
+    },
+    file_selector = {
+      provider = nil,
+      -- Options override for custom providers
+      provider_opts = {},
+    },
+    selector = {
+      provider = "telescope",
+      provider_opts = {},
+      exclude_auto_select = {}, -- List of items to exclude from auto selection
+    },
+    suggestion = {
+      debounce = 600,
+      throttle = 600,
+    },
+    disabled_tools = {},
+    custom_tools = {},
+    slash_commands = {},
   },
-  init = function()
-    require("avante.config").override({
-      system_prompt = require("plugins.user.tools.external.ai.system_prompt").SystemPrompt,
-    })
-  end,
 })

--- a/home/dotfiles/lvim/lvim/lua/plugins/user/tools/internal/img-clip-nvim.lua
+++ b/home/dotfiles/lvim/lvim/lua/plugins/user/tools/internal/img-clip-nvim.lua
@@ -1,0 +1,18 @@
+-- setup for image pasting
+table.insert(lvim.plugins, {
+  -- support for image pasting
+  "HakonHarnes/img-clip.nvim",
+  lazy = true,
+  opts = {
+    -- recommended settings
+    default = {
+      embed_image_as_base64 = false,
+      prompt_for_file_name = false,
+      drag_and_drop = {
+        insert_mode = true,
+      },
+      -- required for Windows users
+      use_absolute_path = true,
+    },
+  },
+})


### PR DESCRIPTION
- update `avante.nvim` configuration to latest version
- add support for agentic mode as default
- expand Copilot integration with additional settings
- add configurations for RAG service and web search capabilities
- move `img-clip.nvim` plugin to a separate file for better organization
- update `history`, `highlights`, and `window` settings
- replace init block with direct configuration in opts table