### PR TITLE
🐞fix(lunarvim/neovim): fix search behavior and unify option settings

### DIFF
--- a/home/dotfiles/lvim/lvim/lua/config/options.lua
+++ b/home/dotfiles/lvim/lvim/lua/config/options.lua
@@ -32,10 +32,10 @@ vim.opt.mouse = ""
 vim.opt.guicursor:append("i:block,a:-blinkwait175-blinkoff150-blinkon175")
 -- search
 vim.opt.hlsearch = true
-vim.opt.ignorecase = true
+vim.opt.ignorecase = false
 vim.opt.smartcase = true
 vim.opt.incsearch = true
-vim.cmd([[set nowrapscan]])
+vim.opt.wrapscan = false
 -- command history
 vim.opt.history = 1000
 -- complement

--- a/home/dotfiles/nvim/nvim/lua/config/options.lua
+++ b/home/dotfiles/nvim/nvim/lua/config/options.lua
@@ -32,10 +32,10 @@ vim.opt.mouse = ""
 vim.opt.guicursor:append("i:block,a:-blinkwait175-blinkoff150-blinkon175")
 -- search
 vim.opt.hlsearch = true
-vim.opt.ignorecase = true
+vim.opt.ignorecase = false
 vim.opt.smartcase = true
 vim.opt.incsearch = true
-vim.cmd([[set nowrapscan]])
+vim.opt.wrapscan = false
 -- command history
 vim.opt.history = 1000
 -- complement


### PR DESCRIPTION
- change `ignorecase` option from `true` to `false` for case-sensitive search
- replace `vim.cmd([[set nowrapscan]])` with `vim.opt.wrapscan = false` for consistency in option setting style
- applied same changes to both LunarVim and Neovim configurations