### PR TITLE
🐞fix(neovim): require double `ESC` to exit terminal mode

### DIFF
--- a/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/toggleterm_nvim.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/toggleterm_nvim.lua
@@ -58,7 +58,7 @@ return {
 				"<CMD>lua ToggleLazyGit()<CR>",
 				{ desc = "lazygit", silent = true, noremap = true }
 			)
-			vim.keymap.set("t", "<Esc>", [[<C-\><C-n>]], { noremap = true })
+			vim.keymap.set("t", "<ESC><ESC>", [[<C-\><C-n>]], { noremap = true })
 			vim.keymap.set("t", "<C-h>", [[<C-\><C-n><C-w>h]], { noremap = true, silent = true })
 			vim.keymap.set("t", "<C-j>", [[<C-\><C-n><C-w>j]], { noremap = true, silent = true })
 			vim.keymap.set("t", "<C-k>", [[<C-\><C-n><C-w>k]], { noremap = true, silent = true })


### PR DESCRIPTION
- change terminal mode mapping from `<Esc>` to `<ESC><ESC>`
- this prevents accidental exits from terminal mode when using applications that rely on the escape key
- improves user experience by reducing unintended mode switches