### PR TITLE
📚doc: Update go packages installation message in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -912,7 +912,7 @@ ifeq ($(IS_WINDOWS),1)
 	@Write-Host ""
 	Get-Content -Path "$$HOME\ghq\github.com\yanosea\yanoNixFiles\pkglist\ghq\pkglist.txt" | ForEach-Object { & ghq get $$_ }
 	@Write-Host ""
-	@Write-Host "clone go shortage repos..." $(COLOR_HEADER)
+	@Write-Host "install go shortage packages..." $(COLOR_HEADER)
 	@Write-Host ""
 	Get-Content -Path "$$HOME\ghq\github.com\yanosea\yanoNixFiles\pkglist\go\pkglist.txt" | ForEach-Object { & go install $$_ }
 	@Write-Host ""


### PR DESCRIPTION
- change log message from `clone go shortage repos...` to `install go shortage packages...` to better reflect the actual operation being performed
- this is a documentation-only change that improves clarity of the build process output