### PR TITLE
🐞fix(workflow): add required permissions to update-flake-lock action

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 15 * * *" # run at 15:00 UTC (0:00 JST)
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-flake:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- add explicit permissions for GitHub Actions workflow
- grant write access to repository contents
- grant write access to pull requests
- ensures the workflow can properly create PRs for flake updates