### PR TITLE
👷chore(workflow): add explicit bot identity to flake update PR

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -130,6 +130,8 @@ jobs:
           body: ${{ steps.update-flake.outputs.commit_body }}
           branch: ${{ steps.update-flake.outputs.branch_name }}
           delete-branch: true
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           labels: |
             dependencies
             automated


### PR DESCRIPTION
- add explicit committer and author information to the `create-pull-request` action in the `flake.lock` update workflow
- ensure GitHub Actions bot is properly identified in automated PRs