### PR TITLE
🔨refactor(neovim): migrate dev tools from `nix` to `mason`

### DIFF
--- a/home/dotfiles/nvim/nvim/lua/plugins/languages/dap/adapters/nvim_dap_go.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/languages/dap/adapters/nvim_dap_go.lua
@@ -8,7 +8,7 @@ return {
 			-- dap-go config
 			require("dap-go").setup({
 				delve = {
-					path = "dlv",
+					path = vim.fn.stdpath("data") .. "/mason/bin/dlv",
 					initialize_timeout_sec = 20,
 					port = "${port}",
 					build_flags = "",

--- a/home/dotfiles/nvim/nvim/lua/plugins/languages/lsp/config/mason.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/languages/lsp/config/mason.lua
@@ -30,10 +30,19 @@ return {
 				ensure_installed = ensure_installed_server,
 			})
 			-- install tools
+			local registry = require("mason-registry")
 			local ensure_installed_tools = require("plugins.languages.lsp.utils.server_list").tools
 			require("mason-tool-installer").setup({
 				ensure_installed = ensure_installed_tools,
 			})
+			registry.refresh(function()
+				for _, name in pairs(ensure_installed_tools) do
+					local package = registry.get_package(name)
+					if not registry.is_installed(name) then
+						package:install()
+					end
+				end
+			end)
 		end,
 	},
 }

--- a/home/dotfiles/nvim/nvim/lua/plugins/languages/lsp/servers/efm.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/languages/lsp/servers/efm.lua
@@ -61,6 +61,10 @@ function M.setup()
 				nix = {
 					require("efmls-configs.formatters.nixfmt"),
 				},
+				-- rust
+				rust = {
+					require("efmls-configs.formatters.rustfmt"),
+				},
 				-- shell
 				sh = {
 					require("efmls-configs.formatters.shfmt"),

--- a/home/dotfiles/nvim/nvim/lua/plugins/languages/lsp/utils/server_list.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/languages/lsp/utils/server_list.lua
@@ -44,6 +44,7 @@ M.tools = {
 	-- docker
 	"hadolint",
 	-- go
+	"delve",
 	"goimports",
 	"golangci-lint",
 	-- lua
@@ -52,6 +53,8 @@ M.tools = {
 	"checkmake",
 	-- nix
 	"nixpkgs-fmt",
+	-- rustfmt
+	"rustfmt",
 	-- shell
 	"shfmt",
 	"shellcheck",

--- a/home/programs/languages/go.nix
+++ b/home/programs/languages/go.nix
@@ -2,7 +2,6 @@
 {
   home = {
     packages = with pkgs; [
-      delve
       go
       goreleaser
       gotests

--- a/home/programs/languages/lua.nix
+++ b/home/programs/languages/lua.nix
@@ -3,8 +3,6 @@
   home = {
     packages = with pkgs; [
       lua
-      lua-language-server
-      stylua
     ];
   };
 }

--- a/home/programs/languages/rust.nix
+++ b/home/programs/languages/rust.nix
@@ -2,11 +2,10 @@
 {
   home = {
     packages = with pkgs; [
-      cargo
       cargo-cross
       cargo-make
       cargo-update
-      rustfmt
+      rustup
     ];
   };
 }


### PR DESCRIPTION
- move `delve` debugger from `nix` package to `mason`
- update path to `delve` in `nvim-dap-go` configuration
- add `delve` to `mason-tool-installer`'s `ensure_installed` list
- remove `lua-language-serve`r and `stylua` from nix packages
- replace `cargo/rustfmt` with `rustup` in nix packages
- add `rustfmt` to `mason` tools and `efm` configuration
- implement `auto-installation` for mason tools on refresh