### PR TITLE
👷chore(workflow): add assignee to flake-lock update workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -132,6 +132,7 @@ jobs:
           delete-branch: true
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          assignees: yanosea
           labels: |
             dependencies
             automated


### PR DESCRIPTION
- add `yanosea` as the default assignee for pull requests created by the automatic `flake.lock` update workflow
- this ensures that notifications are properly routed and improves visibility of dependency update PRs