### PR TITLE
🐞fix(workflow): restrict auto-merge workflow to `flake.lock` updates …

### DIFF
--- a/.github/workflows/auto-merge-dependencies-pr.yml
+++ b/.github/workflows/auto-merge-dependencies-pr.yml
@@ -6,6 +6,8 @@ on:
       - opened
       - labeled
       - synchronize
+    branches:
+      - 'auto-update/flake-lock/**'
 
 permissions:
   contents: write
@@ -16,7 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       contains(github.event.pull_request.labels.*.name, 'dependencies') &&
-      contains(github.event.pull_request.labels.*.name, 'automated')
+      contains(github.event.pull_request.labels.*.name, 'automated') &&
+      startsWith(github.event.pull_request.head.ref, 'auto-update/flake-lock/')
     permissions:
       pull-requests: write
     steps:
@@ -28,7 +31,8 @@ jobs:
     needs: auto-approve
     if: |
       contains(github.event.pull_request.labels.*.name, 'dependencies') &&
-      contains(github.event.pull_request.labels.*.name, 'automated')
+      contains(github.event.pull_request.labels.*.name, 'automated') &&
+      startsWith(github.event.pull_request.head.ref, 'auto-update/flake-lock/')
     steps:
       - name: enable auto-merge
         run: gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
- add branch filter to limit workflow to `auto-update/flake-lock/**`
- add branch name validation to prevent `auto-approval/merging` of unintended PRs
- ensure auto-merge functionality only works for `flake.lock` update PRs