### PR TITLE
🐞fix: improve auto-merge workflow trigger conditions

### DIFF
--- a/.github/workflows/auto-merge-dependencies-pr.yml
+++ b/.github/workflows/auto-merge-dependencies-pr.yml
@@ -6,8 +6,8 @@ on:
       - opened
       - labeled
       - synchronize
-    branches:
-      - "auto-update/flake-lock/**"
+    paths:
+      - "flake.lock"
 
 permissions:
   contents: write


### PR DESCRIPTION
- change trigger condition from branch name pattern to file path
- focus workflow execution specifically on `flake.lock` file changes
- this ensures the workflow runs only when the relevant dependency file is modified, regardless of the branch name