### PR TITLE
🐞fix: remove path restriction from auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-dependencies-pr.yml
+++ b/.github/workflows/auto-merge-dependencies-pr.yml
@@ -6,8 +6,6 @@ on:
       - opened
       - labeled
       - synchronize
-    paths:
-      - "flake.lock"
 
 permissions:
   contents: write


### PR DESCRIPTION
- remove path restriction that limited the workflow to only run on PRs affecting `flake.lock`
- this allows the auto-merge to work on dependency updates that might include changes to other files