### PR TITLE
🐞fix: Improve auto-merge workflow with workflow_run

### DIFF
--- a/.github/workflows/auto-merge-dependencies-pr.yml
+++ b/.github/workflows/auto-merge-dependencies-pr.yml
@@ -1,28 +1,64 @@
 name: Auto merge updating flake.lock PR
 
 on:
-  pull_request:
-    types:
-      - opened
-      - labeled
-      - synchronize
   pull_request_target:
     types:
       - opened
       - labeled
       - synchronize
+  workflow_run:
+    workflows: ["Update flake.lock"]
+    types:
+      - completed
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
+  find-pr:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
+    outputs:
+      pr_number: ${{ steps.find-pr.outputs.pr_number }}
+      pr_data: ${{ steps.find-pr.outputs.pr_data }}
+    steps:
+      - name: Find associated PR
+        id: find-pr
+        run: |
+          PR_DATA=$(gh api graphql -f query='
+            query($owner:String!, $repo:String!, $base_sha:String!) {
+              repository(owner:$owner, name:$repo) {
+                pullRequests(first:1, orderBy:{field:CREATED_AT, direction:DESC}, baseRefName:"main") {
+                  nodes {
+                    number
+                    headRefName
+                    labels(first:10) {
+                      nodes {
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }' -F owner=$GITHUB_REPOSITORY_OWNER -F repo=$(echo $GITHUB_REPOSITORY | cut -d/ -f2) -F base_sha=${{ github.event.workflow_run.head_sha }})
+          PR_NUMBER=$(echo "$PR_DATA" | jq -r '.data.repository.pullRequests.nodes[0].number')
+          HEAD_REF=$(echo "$PR_DATA" | jq -r '.data.repository.pullRequests.nodes[0].headRefName')
+          HAS_DEPENDENCIES=$(echo "$PR_DATA" | jq '.data.repository.pullRequests.nodes[0].labels.nodes[].name | contains("dependencies")' | grep -q true && echo "true" || echo "false")
+          HAS_AUTOMATED=$(echo "$PR_DATA" | jq '.data.repository.pullRequests.nodes[0].labels.nodes[].name | contains("automated")' | grep -q true && echo "true" || echo "false")
+          if [[ "$HAS_DEPENDENCIES" == "true" && "$HAS_AUTOMATED" == "true" && "$HEAD_REF" == auto-update/flake-lock/* ]]; then
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "pr_data=$PR_DATA" >> $GITHUB_OUTPUT
+          else
+            echo "No matching PR found or PR doesn't have required labels"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   auto-approve:
     runs-on: ubuntu-latest
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'dependencies') &&
-      contains(github.event.pull_request.labels.*.name, 'automated') &&
-      startsWith(github.event.pull_request.head.ref, 'auto-update/flake-lock/')
+    needs: find-pr
+    if: needs.find-pr.outputs.pr_number != ''
     permissions:
       pull-requests: write
     steps:
@@ -30,23 +66,17 @@ jobs:
         uses: hmarr/auto-approve-action@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ needs.find-pr.outputs.pr_number }}
 
   auto-merge:
     runs-on: ubuntu-latest
-    needs: auto-approve
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'dependencies') &&
-      contains(github.event.pull_request.labels.*.name, 'automated') &&
-      startsWith(github.event.pull_request.head.ref, 'auto-update/flake-lock/')
+    needs: [find-pr, auto-approve]
+    if: needs.find-pr.outputs.pr_number != ''
     steps:
       - name: enable auto-merge
         run: |
-          echo "PR URL: $PR_URL"
-          echo "PR Labels: ${{ toJSON(github.event.pull_request.labels) }}"
-          echo "PR Branch: ${{ github.event.pull_request.head.ref }}"
-          echo "PR Number: ${{ github.event.pull_request.number }}"
+          echo "PR Number: $PR_NUMBER"
           gh pr merge --auto --merge "$PR_NUMBER"
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ needs.find-pr.outputs.pr_number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- add workflow_run trigger to process completed "Update flake.lock" runs
- add new find-pr job to locate PRs associated with workflow runs
- replace direct PR event handling with PR discovery via GraphQL API
- simplify conditions by passing PR number between workflow jobs
- remove redundant debugging output in auto-merge step