### PR TITLE
✨feat(nix, rust): integrate `fenix` for rust toolchain management

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -53,6 +53,27 @@
         "type": "github"
       }
     },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1748759782,
+        "narHash": "sha256-MJNhEBsAbxRp/53qsXv6/eaWkGS8zMGX9LuCz1BLeck=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "9be40ad995bac282160ff374a47eed67c74f9c2a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -467,12 +488,30 @@
     "root": {
       "inputs": {
         "darwin": "darwin",
+        "fenix": "fenix",
         "home-manager": "home-manager",
         "hyprland": "hyprland",
         "nixos-hardware": "nixos-hardware",
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1748695646,
+        "narHash": "sha256-VwSuuRF4NvAoeHZJRRlX8zAFZ+nZyuiIvmVqBAX0Bcg=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "2a388d1103450d814a84eda98efe89c01b158343",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,15 @@
         };
       };
     };
+    ## rust
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs = {
+        nixpkgs = {
+          follows = "nixpkgs";
+        };
+      };
+    };
     # packages
     ## hyprland
     hyprland = {

--- a/home/programs/languages/rust.nix
+++ b/home/programs/languages/rust.nix
@@ -4,8 +4,11 @@
     packages = with pkgs; [
       cargo-cross
       cargo-make
-      cargo-update
-      rustup
+      (fenix.combine [
+        fenix.latest.toolchain
+        fenix.targets.wasm32-unknown-unknown.latest.rust-std
+        fenix.targets.wasm32-wasi.latest.rust-std
+      ])
     ];
   };
 }

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -62,12 +62,13 @@ let
     {
       homePath,
       modules,
+      overlays,
       system,
       username,
     }:
     inputs.home-manager.lib.homeManagerConfiguration {
       pkgs = import inputs.nixpkgs {
-        inherit system;
+        inherit overlays system;
         config = {
           allowUnfree = true;
         };
@@ -135,6 +136,7 @@ in
     "yanosea@yanoNixOs" = mkHomeManagerConfiguration {
       homePath = "/home";
       modules = [ ./yanoNixOs/home.nix ];
+      overlays = [ inputs.fenix.overlays.default ];
       system = "x86_64-linux";
       username = "yanosea";
     };
@@ -142,6 +144,7 @@ in
     "yanosea@yanoNixOsWsl" = mkHomeManagerConfiguration {
       homePath = "/home";
       modules = [ ./yanoNixOsWsl/home.nix ];
+      overlays = [ inputs.fenix.overlays.default ];
       system = "x86_64-linux";
       username = "yanosea";
     };
@@ -149,6 +152,7 @@ in
     "yanosea@yanoMac" = mkHomeManagerConfiguration {
       homePath = "/Users";
       modules = [ ./yanoMac/home.nix ];
+      overlays = [ inputs.fenix.overlays.default ];
       system = "aarch64-darwin";
       username = "yanosea";
     };
@@ -156,6 +160,7 @@ in
     "yanosea@yanoMacBook" = mkHomeManagerConfiguration {
       homePath = "/Users";
       modules = [ ./yanoMacBook/home.nix ];
+      overlays = [ inputs.fenix.overlays.default ];
       system = "aarch64-darwin";
       username = "yanosea";
     };


### PR DESCRIPTION
- add `fenix` as flake input for better rust toolchain management
- replace `rustup` with `fenix`'s combined toolchain in home configuration
- include wasm targets (wasm32-unknown-unknown and wasm32-wasi)
- update home-manager configurations to use `fenix` overlay
- support consistent rust environment across all systems