### PR TITLE
🐞fix(neovim): load lsp plugins eagerly to ensure availability

### DIFF
--- a/home/dotfiles/nvim/nvim/lua/plugins/languages/lsp/config/mason.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/languages/lsp/config/mason.lua
@@ -6,21 +6,7 @@ return {
 			"williamboman/mason-lspconfig.nvim",
 			"WhoIsSethDaniel/mason-tool-installer.nvim",
 		},
-		lazy = true,
-		event = { "BufReadPost", "BufNewFile" },
-		cmd = {
-			"Mason",
-			"MasonUpdate",
-			"MasonLog",
-			"MasonInstall",
-			"MasonUninstall",
-			"MasonToolsClean",
-			"MasonToolsUpdate",
-			"MasonToolsInstall",
-			"MasonUninstallAll",
-			"MasonToolsUpdateSync",
-			"MasonToolsInstallSync",
-		},
+		lazy = false,
 		config = function()
 			-- setup mason
 			require("mason").setup()

--- a/home/dotfiles/nvim/nvim/lua/plugins/languages/lsp/config/nvim_lspconfig.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/languages/lsp/config/nvim_lspconfig.lua
@@ -10,8 +10,7 @@ return {
 			"creativenull/efmls-configs-nvim",
 			"b0o/schemastore.nvim",
 		},
-		lazy = true,
-		event = { "BufReadPost", "BufNewFile" },
+		lazy = false,
 		config = function()
 			-- keymaps
 			require("plugins.languages.lsp.utils.keymaps").setup()

--- a/home/dotfiles/nvim/nvim/lua/plugins/languages/lsp/config/nvim_treesitter.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/languages/lsp/config/nvim_treesitter.lua
@@ -2,17 +2,7 @@
 return {
 	{
 		"nvim-treesitter/nvim-treesitter",
-		lazy = true,
-		event = { "BufReadPost", "BufNewFile" },
-		cmd = {
-			"TSInstall",
-			"TSInstallInfo",
-			"TSInstallFromGrammar",
-			"TSInstallSync",
-			"TSUpdate",
-			"TSUpdateSync",
-			"TSUninstall",
-		},
+		lazy = false,
 		config = function()
 			-- nvim-treesitter config
 			require("nvim-treesitter.configs").setup({


### PR DESCRIPTION
- change loading strategy for lsp-related plugins from lazy to eager
- remove event triggers and command lists from `mason`, `lspconfig`, and `treesitter` plugins
- this ensures lsp functionality is available immediately at startup rather than waiting for buffer events