### PR TITLE
🐞fix: correct documentation prefix from `doc:` to `docs:`

### DIFF
--- a/home/dotfiles/nvim/nvim/lua/plugins/tools/external/ai/prompts/user_prompts/commit.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/tools/external/ai/prompts/user_prompts/commit.lua
@@ -9,7 +9,7 @@ For the title, use one of the following prefixes, separated from the title by a 
   - Use for new feature additions
 - fix:
   - Use for bug fixes
-- doc:
+- docs:
   - Use for documentation-only changes
 - style:
   - Use for changes that do not affect program behavior (indentation adjustments, formatting, etc.)


### PR DESCRIPTION
- standardized the documentation-related commit prefix to use `docs:` instead of `doc:` in the commit message generation prompt
- this change ensures consistency with conventional commit standards