### PR TITLE
🐞fix: improve audio configuration and UI presentation

### DIFF
--- a/home/dotfiles/waybar/waybar/config
+++ b/home/dotfiles/waybar/waybar/config
@@ -85,7 +85,7 @@
     "tooltip": false
   },
   "pulseaudio": {
-    "format": "{icon} {volume}%",
+    "format": "{icon}  {volume}%",
     "format-bluetooth": "{icon} {volume}%",
     "format-muted": "",
     "format-icons": {

--- a/modules/desktop/default.nix
+++ b/modules/desktop/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./environment.nix
     ./fonts.nix
     ./security.nix
     ./sound.nix

--- a/modules/desktop/environment.nix
+++ b/modules/desktop/environment.nix
@@ -1,5 +1,10 @@
+{ pkgs, ... }:
 {
   environment = {
+    systemPackages = with pkgs; [
+      pulseaudio
+      pavucontrol
+    ];
     variables = {
       LIBVA_DRIVER_NAME = "nvidia";
       VDPAU_DRIVER = "nvidia";

--- a/modules/desktop/sound.nix
+++ b/modules/desktop/sound.nix
@@ -11,8 +11,6 @@
       enable = true;
       alsa = {
         enable = true;
-      };
-      alsa = {
         support32Bit = true;
       };
       jack = {

--- a/modules/programs/media.nix
+++ b/modules/programs/media.nix
@@ -1,8 +1,5 @@
 {
   programs = {
-    droidcam = {
-      enable = true;
-    };
     noisetorch = {
       enable = true;
     };


### PR DESCRIPTION
- add extra space in waybar volume indicator for better readability
- include `pulseaudio` and `pavucontrol` in system packages
- fix duplicate ALSA configuration in `sound.nix`
- remove unused `droidcam` configuration