### PR TITLE
✨feat: add `orgmode` support and remap `Oil` shortcut

### DIFF
--- a/home/dotfiles/nvim/nvim/lua/plugins/languages/lsp/config/nvim_treesitter.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/languages/lsp/config/nvim_treesitter.lua
@@ -71,6 +71,9 @@ return {
 					-- yaml
 					"yaml",
 				},
+				ignore_install = {
+					"org",
+				},
 			})
 		end,
 	},

--- a/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/orgmode.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/orgmode.lua
@@ -1,0 +1,17 @@
+-- neovim org-mode
+return {
+	{
+		"nvim-orgmode/orgmode",
+		event = "VeryLazy",
+		ft = { "org" },
+		config = function()
+			local orgfiles_path = vim.env.GOOGLE_DRIVE and vim.env.GOOGLE_DRIVE .. "/orgfiles"
+				or "~/.local/share/nvim/orgfiles"
+			-- orgmode config
+			require("orgmode").setup({
+				org_agenda_files = orgfiles_path .. "/**/*",
+				org_default_notes_file = orgfiles_path .. "/refile.org",
+			})
+		end,
+	},
+}

--- a/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/which_key_nvim.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/which_key_nvim.lua
@@ -163,7 +163,7 @@ return {
 					{ "<LEADER>lT", "<CMD>TodoLocList<CR>", desc = "lsp: todo location list" },
 					{ "<LEADER>lw", "<CMD>Telescope diagnostics<CR>", desc = "lsp: diagnostics" },
 					-- markdown
-					{ "LEADER>m", group = "markdown" },
+					{ "<LEADER>m", group = "markdown" },
 					{ "<LEADER>mp", "<CMD>PeekOpen<CR>", desc = "markdown: preview in browser" },
 					{ "<LEADER>mt", "<CMD>RenderMarkdown toggle<CR>", desc = "markdown: preview toggle" },
 					-- noice

--- a/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/which_key_nvim.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/which_key_nvim.lua
@@ -175,8 +175,10 @@ return {
 					{ "<LEADER>nh", "<CMD>NoiceHistory<CR>", desc = "noice: message history" },
 					{ "<LEADER>nl", "<CMD>NoiceLast<CR>", desc = "noice: last message" },
 					{ "<LEADER>ns", "<CMD>Noice<CR>", desc = "noice: show" },
+					-- org mode (grouping)
+					{ "<LEADER>o", group = "orgmode" },
 					-- oil explorer
-					{ "<LEADER>o", "<CMD>Oil<CR>", desc = "oil" },
+					{ "<LEADER>O", "<CMD>Oil<CR>", desc = "oil" },
 					-- plugins
 					{ "<LEADER>p", group = "plugins" },
 					{ "<LEADER>pc", "<CMD>Lazy clean<CR>", desc = "plugins: clean" },


### PR DESCRIPTION
- fix missing opening bracket in markdown keybinding group definition
- the `<` character was missing in `<LEADER>m` for markdown group
- this ensures markdown-related key mappings work properly