### PR TITLE
🔨refactor: improve `orgmode` config with lazy loading

### DIFF
--- a/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/orgmode.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/orgmode.lua
@@ -1,7 +1,9 @@
 -- neovim org-mode
+-- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>o, for grouping)
 return {
 	{
 		"nvim-orgmode/orgmode",
+		lazy = true,
 		event = "VeryLazy",
 		ft = { "org" },
 		config = function()

--- a/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/which_key_nvim.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/which_key_nvim.lua
@@ -175,7 +175,7 @@ return {
 					{ "<LEADER>nh", "<CMD>NoiceHistory<CR>", desc = "noice: message history" },
 					{ "<LEADER>nl", "<CMD>NoiceLast<CR>", desc = "noice: last message" },
 					{ "<LEADER>ns", "<CMD>Noice<CR>", desc = "noice: show" },
-					-- org mode (grouping)
+					-- org mode (for grouping)
 					{ "<LEADER>o", group = "orgmode" },
 					-- oil explorer
 					{ "<LEADER>O", "<CMD>Oil<CR>", desc = "oil" },


### PR DESCRIPTION
- add lazy loading for `orgmode` plugin to improve startup time
- add comment documenting where `orgmode` keymaps are configured
- minor comment improvement in `which_key_nvim.lua`