### PR TITLE
✨feat: add `grug-far.nvim` plugin for text search and replace

### DIFF
--- a/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/grug_far_nvim.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/grug_far_nvim.lua
@@ -1,0 +1,13 @@
+-- search and replace text
+-- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>G)
+return {
+	{
+		"MagicDuck/grug-far.nvim",
+		lazy = true,
+		cmd = { "GrugFar", "GrugFarWithin" },
+		config = function()
+			-- grug-far.nvim config
+			require("grug-far").setup()
+		end,
+	},
+}

--- a/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/which_key_nvim.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/which_key_nvim.lua
@@ -131,6 +131,8 @@ return {
 					{ "<LEADER>gs", "<CMD>Gitsigns stage_hunk<CR>", desc = "git: stage hunk" },
 					{ "<LEADER>gu", "<CMD>Gitsigns undo_stage_hunk<CR>", desc = "git: undo stage hunk" },
 					{ "<LEADER>gU", "<CMD>OpenGitHubUrlUnderCursor<CR>", desc = "git: open github url" },
+					-- grug far
+					{ "<LEADER>G", "<CMD>GrugFar<CR>", desc = "grug far: search and replace text" },
 					-- lsp
 					{ "<LEADER>l", group = "lsp" },
 					{ "<LEADER>la", "<CMD>lua vim.lsp.buf.code_action()<CR>", desc = "lsp: code action" },


### PR DESCRIPTION
- add `grug-far.nvim` plugin for advanced text search and replace
- configure plugin to be lazy-loaded on command usage
- add keybinding `<LEADER>G` to activate `GrugFar` command
- include descriptive comment in `which_key` configuration