### PR TITLE
✨feat: add `readermode.nvim` plugin for centered reading

### DIFF
--- a/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/readermode_nvim.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/readermode_nvim.lua
@@ -1,0 +1,13 @@
+-- keeping cursor centered while reading through code/text/whatever
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>R)
+return {
+	{
+		"sarrisv/readermode.nvim",
+		lazy = true,
+		cmd = { "ReaderMode" },
+		opts = {
+			enable = true,
+			keymap = "<LEADER>R",
+		},
+	},
+}

--- a/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/which_key_nvim.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/which_key_nvim.lua
@@ -195,6 +195,8 @@ return {
 					{ "<LEADER>w", "<CMD>w!<CR>", desc = "save buffer" },
 					-- quit
 					{ "<LEADER>q", "<CMD>confirm q<CR>", desc = "quit" },
+					-- reader mode
+					{ "<LEADER>R", "<CMD>ReaderMode<CR>", desc = "reader mode: toggle" },
 					-- search
 					{ "<LEADER>s", group = "search" },
 					{ "<LEADER>sb", "<CMD>Telescope git_branches<CR>", desc = "search: checkout branch" },


### PR DESCRIPTION
- add `readermode.nvim` plugin configuration
- configure with `<LEADER>R` keybinding to toggle reader mode
- update `which-key` mappings to include the new functionality