### PR TITLE
✨feat: add `smear-cursor.nvim` for animated cursor effects

### DIFF
--- a/home/dotfiles/nvim/nvim/lua/plugins/editor/navigation/winpick_nvim.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/editor/navigation/winpick_nvim.lua
@@ -17,6 +17,7 @@ return {
 					local excluded_filetypes = {
 						"noice",
 						"notify",
+						"smear-cursor",
 					}
 					if vim.tbl_contains(excluded_filetypes, filetype) then
 						is_excluded = true

--- a/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/smear_cursor_nvim.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/smear_cursor_nvim.lua
@@ -1,0 +1,22 @@
+-- cursor animation like Neovide
+-- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>S)
+return {
+	{
+		"sphamba/smear-cursor.nvim",
+		lazy = true,
+		event = "VeryLazy",
+		opts = {
+			smear_between_buffers = true,
+			smear_between_neighbor_lines = true,
+			scroll_buffer_space = true,
+			legacy_computing_symbols_support = false,
+			smear_insert_mode = true,
+			stiffness = 0.8,
+			trailing_stiffness = 0.5,
+			stiffness_insert_mode = 0.6,
+			trailing_stiffness_insert_mode = 0.6,
+			distance_stop_animating = 0.5,
+			time_interval = 7,
+		},
+	},
+}

--- a/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/which_key_nvim.lua
+++ b/home/dotfiles/nvim/nvim/lua/plugins/tools/internal/which_key_nvim.lua
@@ -217,6 +217,8 @@ return {
 					{ "<LEADER>sr", "<CMD>Telescope oldfiles<CR>", desc = "search: recent file" },
 					{ "<LEADER>sR", "<CMD>Telescope registers<CR>", desc = "search: registers" },
 					{ "<LEADER>st", "<CMD>Telescope live_grep<CR>", desc = "search: text" },
+					-- smear cursor
+					{ "<LEADER>S", "<CMD>SmearCursorToggle<CR>", desc = "smearcursor: toggle" },
 					-- terminal
 					{ "<LEADER>t", "<CMD>ToggleTerm<CR>", desc = "terminal" },
 					-- translate


### PR DESCRIPTION
- add `smear-cursor.nvim` plugin for `Neovide`-like cursor animations
- configure `smear-cursor` with optimal animation settings
- register `smear-cursor` filetype as excluded in `winpick`
- add `which-key` mapping for toggling `smear-cursor` (`<LEADER>S`)