### PR TITLE
🔨refactor: centralize overlays management

### DIFF
--- a/home/programs/gui/media.nix
+++ b/home/programs/gui/media.nix
@@ -1,11 +1,11 @@
-{ inputs, pkgs, ... }:
+{ pkgs, ... }:
 {
   # home
   home = {
     packages = (
       with pkgs;
       [
-        inputs.mediaplayer.packages.${pkgs.system}.default
+        mediaplayer
         evince
         spotify
         totem

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -136,7 +136,7 @@ in
     "yanosea@yanoNixOs" = mkHomeManagerConfiguration {
       homePath = "/home";
       modules = [ ./yanoNixOs/home.nix ];
-      overlays = [ inputs.fenix.overlays.default ];
+      overlays = import ../overlays inputs;
       system = "x86_64-linux";
       username = "yanosea";
     };
@@ -144,7 +144,7 @@ in
     "yanosea@yanoNixOsWsl" = mkHomeManagerConfiguration {
       homePath = "/home";
       modules = [ ./yanoNixOsWsl/home.nix ];
-      overlays = [ inputs.fenix.overlays.default ];
+      overlays = import ../overlays inputs;
       system = "x86_64-linux";
       username = "yanosea";
     };
@@ -152,7 +152,7 @@ in
     "yanosea@yanoMac" = mkHomeManagerConfiguration {
       homePath = "/Users";
       modules = [ ./yanoMac/home.nix ];
-      overlays = [ inputs.fenix.overlays.default ];
+      overlays = import ../overlays inputs;
       system = "aarch64-darwin";
       username = "yanosea";
     };
@@ -160,7 +160,7 @@ in
     "yanosea@yanoMacBook" = mkHomeManagerConfiguration {
       homePath = "/Users";
       modules = [ ./yanoMacBook/home.nix ];
-      overlays = [ inputs.fenix.overlays.default ];
+      overlays = import ../overlays inputs;
       system = "aarch64-darwin";
       username = "yanosea";
     };

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -1,0 +1,6 @@
+inputs: [
+  inputs.fenix.overlays.default
+  (final: prev: {
+    mediaplayer = inputs.mediaplayer.packages.${prev.system}.default;
+  })
+]


### PR DESCRIPTION
- create `overlays` directory with `default.nix `to manage all overlays
- change `mediaplayer` package to be accessed through overlay
- update `home-manager` configurations to use centralized overlays