### PR TITLE
🔨refactor: simplify cat command path on Linux systems in `show_random…

### DIFF
--- a/home/config/zsh/functions/show_random_aa
+++ b/home/config/zsh/functions/show_random_aa
@@ -6,6 +6,6 @@ function show_random_aa() {
   if [[ "$OS" = "Darwin" ]]; then
     /bin/cat $random_file
   elif [[ "$OS" = "Linux" ]]; then
-    /run/current-system/sw/bin/cat $random_file
+    cat $random_file
   fi
 }


### PR DESCRIPTION
…_aa` function

- replace absolute path to cat command with relative path on Linux
- this makes the function more portable across different Linux distributions
- matches the simpler approach already used for Darwin (macOS) systems