### PR TITLE
🐞fix: update remaining `.gitignore` paths after `a0ea5b9c`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # IGNORE DIRECTORY
-home/dotfiles/lf/lf/lf/
-home/dotfiles/vim/vim/autoload/
-home/dotfiles/vim/vim/plugged/
+home/config/lf/lf/
+home/config/vim/autoload/
+home/config/vim/plugged/
 # IGNORE FILE
 result
 .DS_Store


### PR DESCRIPTION
- aligned ignored paths with directory structure changes from `a0ea5b9c`
- changed remaining paths from `home/dotfiles/*` to `home/config/*`
- fixed inconsistency in configuration file organization