### PR TITLE
✨feat: add GitHub Copilot and improve dotfiles structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,16 @@
 # IGNORE DIRECTORY
+home/config/go/
 home/config/lf/lf/
 home/config/vim/autoload/
+home/config/vim/undo
+home/config/vim/viminfo
+home/config/wakatime/
 home/config/vim/plugged/
 # IGNORE FILE
+home/config/gh/hosts.yml
+home/config/github-copilot/apps.json
+home/config/github-copilot/versions.json
+home/config/nvim/lazy-lock.json
 result
 .DS_Store
 *.log

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ ifeq ($(IS_NIXOS),1)
 	mkdir -p $$XDG_DATA_HOME/skk
 	mkdir -p $$XDG_STATE_HOME/skk
 	mkdir -p $$XDG_STATE_HOME/zsh
+	mkdir -p $$XDG_CONFIG_HOME/github-copilot
 	mkdir -p $$XDG_CONFIG_HOME/wakatime
 	@echo ""
 	@echo "$(COLOR_HEADER)initialize rclone...$(COLOR_RESET)"
@@ -228,6 +229,7 @@ ifeq ($(IS_NIXOS_WSL),1)
 	mkdir -p $$XDG_DATA_HOME/skk
 	mkdir -p $$XDG_STATE_HOME/skk
 	mkdir -p $$XDG_STATE_HOME/zsh
+	mkdir -p $$XDG_CONFIG_HOME/github-copilot
 	mkdir -p $$XDG_CONFIG_HOME/wakatime
 	@echo ""
 	@echo "$(COLOR_HEADER)make necessary symbolic links...$(COLOR_RESET)"
@@ -370,6 +372,7 @@ ifeq ($(IS_MAC),1)
 	mkdir -p $$XDG_DATA_HOME/skk
 	mkdir -p $$XDG_STATE_HOME/skk
 	mkdir -p $$XDG_STATE_HOME/zsh
+	mkdir -p $$XDG_CONFIG_HOME/github-copilot
 	mkdir -p $$XDG_CONFIG_HOME/wakatime
 	@echo ""
 	@echo "$(COLOR_HEADER)make necessary symbolic links...$(COLOR_RESET)"
@@ -545,6 +548,7 @@ ifeq ($(IS_MACBOOK),1)
 	mkdir -p $$XDG_DATA_HOME/skk
 	mkdir -p $$XDG_STATE_HOME/skk
 	mkdir -p $$XDG_STATE_HOME/zsh
+	mkdir -p $$XDG_CONFIG_HOME/github-copilot
 	mkdir -p $$XDG_CONFIG_HOME/wakatime
 	@echo ""
 	@echo "$(COLOR_HEADER)make necessary symbolic links...$(COLOR_RESET)"

--- a/home/config/github-copilot/versions.json
+++ b/home/config/github-copilot/versions.json
@@ -1,1 +1,0 @@
-{"copilot.vim":"1.35.0","copilot.lua":"1.13.0"}

--- a/home/config/nvim/lua/plugins/ui/components/smear_cursor_nvim.lua
+++ b/home/config/nvim/lua/plugins/ui/components/smear_cursor_nvim.lua
@@ -9,7 +9,7 @@ return {
 			smear_between_buffers = true,
 			smear_between_neighbor_lines = true,
 			scroll_buffer_space = true,
-			legacy_computing_symbols_support = false,
+			legacy_computing_symbols_support = true,
 			smear_insert_mode = true,
 			stiffness = 0.8,
 			trailing_stiffness = 0.5,

--- a/home/config/zsh/functions/gh-copilot-alias-zsh
+++ b/home/config/zsh/functions/gh-copilot-alias-zsh
@@ -4,7 +4,7 @@ ghcs() {
 	local GH_DEBUG="$GH_DEBUG"
 
 	read -r -d '' __USAGE <<-EOF
-	Wrapper around \`gh copilot suggest\` to suggest a command based on a natural language description of the desired output effort.
+	Wrapper around \`gh-copilot suggest\` to suggest a command based on a natural language description of the desired output effort.
 	Supports executing suggested commands if applicable.
 
 	USAGE
@@ -67,7 +67,7 @@ ghcs() {
 
 	TMPFILE="$(mktemp -t gh-copilotXXX)"
 	trap 'rm -f "$TMPFILE"' EXIT
-	if GH_DEBUG="$GH_DEBUG" gh copilot suggest -t "$TARGET" "$@" --shell-out "$TMPFILE"; then
+	if GH_DEBUG="$GH_DEBUG" gh-copilot suggest -t "$TARGET" "$@" --shell-out "$TMPFILE"; then
 		if [ -s "$TMPFILE" ]; then
 			FIXED_CMD="$(cat $TMPFILE)"
 			print -s "$FIXED_CMD"
@@ -84,7 +84,7 @@ ghce() {
 	local GH_DEBUG="$GH_DEBUG"
 
 	read -r -d '' __USAGE <<-EOF
-	Wrapper around \`gh copilot explain\` to explain a given input command in natural language.
+	Wrapper around \`gh-copilot explain\` to explain a given input command in natural language.
 
 	USAGE
 	  $FUNCNAME [flags] <command>
@@ -128,5 +128,5 @@ ghce() {
 	# shift so that $@, $1, etc. refer to the non-option arguments
 	shift "$((OPTIND-1))"
 
-	GH_DEBUG="$GH_DEBUG" gh copilot explain "$@"
+	GH_DEBUG="$GH_DEBUG" gh-copilot explain "$@"
 }

--- a/home/programs/cli/git.nix
+++ b/home/programs/cli/git.nix
@@ -32,6 +32,7 @@
     };
     packages = with pkgs; [
       gh
+      gh-copilot
       gh-dash
       ghq
       git-credential-oauth

--- a/home/programs/languages/lua.nix
+++ b/home/programs/languages/lua.nix
@@ -3,6 +3,7 @@
   home = {
     packages = with pkgs; [
       lua
+      luarocks
     ];
   };
 }


### PR DESCRIPTION
- add GitHub Copilot configuration directory and package
- update `.gitignore` to exclude specific config files and directories
- move `smear_cursor_nvim.lua` from tools to UI components
- enable legacy computing symbols support for `smear_cursor`
- replace `gh copilot` with `gh-copilot` in shell functions
- add `luarocks` package for Lua development