### PR TITLE
🧹chore: ignore temporary files in `glzr/zebar` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IGNORE DIRECTORY
 home/config/go/
+home/config/glzr/zebar/tmp-*
 home/config/lf/lf/
 home/config/vim/autoload/
 home/config/vim/undo


### PR DESCRIPTION
- add pattern to ignore temporary files (`tmp-*`) in `home/config/glzr/zebar`
- temporary files should not be tracked in version control