### PR TITLE
🧹chore: ignore `scoop` config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 home/config/go/
 home/config/glzr/zebar/tmp-*
 home/config/lf/lf/
+home/config/scoop
 home/config/vim/autoload/
 home/config/vim/undo
 home/config/vim/viminfo


### PR DESCRIPTION
- exclude `scoop` configuration directory from version control
- this prevents unnecessary tracking of package manager related files