### PR TITLE
💄style: remove redundant empty line echo in `shell.nix`

### DIFF
--- a/home/programs/cli/shell.nix
+++ b/home/programs/cli/shell.nix
@@ -16,7 +16,6 @@
           echo "updating sheldon plugins..."
           echo ""
           ${script}
-          echo ""
         '';
     };
     packages = with pkgs; [


### PR DESCRIPTION
- remove unnecessary empty line output after `sheldon` plugin update message for cleaner activation output