### PR TITLE
🧹chore: remove `launchpad` and related configurations

### DIFF
--- a/modules/nix/nix-darwin.nix
+++ b/modules/nix/nix-darwin.nix
@@ -187,9 +187,6 @@
           {
             app = "/System/Applications/System Settings.app";
           }
-          {
-            app = "/System/Applications/Launchpad.app";
-          }
         ];
         persistent-others = null;
         scroll-to-open = true;
@@ -287,13 +284,13 @@
         TrackpadThreeFingerDrag = true;
         TrackpadThreeFingerTapGesture = 2;
       };
-      # universalaccess = {
-      #   closeViewScrollWheelToggle = false;
-      #   closeViewZoomFollowsFocus = false;
-      #   mouseDriverCursorSize = 1.0;
-      #   reduceMotion = false;
-      #   reduceTransparency = false;
-      # };
+      universalaccess = {
+        closeViewScrollWheelToggle = false;
+        closeViewZoomFollowsFocus = false;
+        mouseDriverCursorSize = 1.0;
+        reduceMotion = false;
+        reduceTransparency = false;
+      };
     };
     keyboard = {
       enableKeyMapping = true;

--- a/modules/programs/brew.nix
+++ b/modules/programs/brew.nix
@@ -27,7 +27,6 @@
       "hammerspoon"
       "hiddenbar"
       "karabiner-elements"
-      "launchpad-manager"
       "libreoffice"
       "libreoffice-language-pack"
       "microsoft-auto-update"


### PR DESCRIPTION
- remove `launchpad` from dock applications list due to updating macOS 26
- remove `launchpad-manager` from `Homebrew` casks
- uncomment `universalaccess` settings to ensure proper configuration