### PR TITLE
🐞fix: time synchronization with robust services

### DIFF
--- a/modules/core/time.nix
+++ b/modules/core/time.nix
@@ -1,19 +1,15 @@
 { pkgs, ... }:
 {
-  # time
-  time = {
-    hardwareClockInLocalTime = true;
-    timeZone = "Asia/Tokyo";
-  };
   # services
-  services.chrony = {
-    enable = true;
-    servers = [
-      "0.pool.ntp.org"
-      "1.pool.ntp.org"
-      "2.pool.ntp.org"
-      "3.pool.ntp.org"
-    ];
+  services = {
+    chrony = {
+      enable = true;
+      servers = [ "ntp.jst.mfeed.ad.jp" ];
+      serverOption = "iburst";
+      enableRTCTrimming = true;
+      autotrimThreshold = 20;
+      initstepslew.enabled = true;
+    };
   };
   # systemd
   systemd = {
@@ -26,7 +22,10 @@
         ];
         bindsTo = [ "chronyd.service" ];
         wants = [ "network-online.target" ];
-        wantedBy = [ "multi-user.target" ];
+        wantedBy = [
+          "multi-user.target"
+          "time-sync.target"
+        ];
         serviceConfig = {
           Type = "oneshot";
           ExecStartPre = "${pkgs.coreutils}/bin/sleep 2";
@@ -34,6 +33,44 @@
           SuccessExitStatus = "0 1";
         };
       };
+      fix-timezone-early = {
+        description = "Fix timezone before chrony starts";
+        before = [ "chronyd.service" ];
+        after = [ "set-hwclock-early.service" ];
+        unitConfig = {
+          DefaultDependencies = false;
+        };
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStart = "${pkgs.bash}/bin/bash -c '${pkgs.coreutils}/bin/date -s \"$(${pkgs.coreutils}/bin/date)\"'";
+        };
+        wantedBy = [ "basic.target" ];
+      };
+      set-hwclock-early = {
+        description = "Set hardware clock early in boot process";
+        wants = [ "local-fs.target" ];
+        after = [ "local-fs.target" ];
+        before = [
+          "sysinit.target"
+          "chronyd.service"
+        ];
+        conflicts = [ "shutdown.target" ];
+        unitConfig = {
+          DefaultDependencies = false;
+        };
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStart = "${pkgs.util-linux}/bin/hwclock --hctosys --localtime";
+        };
+        wantedBy = [ "basic.target" ];
+      };
     };
+  };
+  # time
+  time = {
+    hardwareClockInLocalTime = true;
+    timeZone = "Asia/Tokyo";
   };
 }

--- a/modules/programs/google-drive.nix
+++ b/modules/programs/google-drive.nix
@@ -22,16 +22,16 @@
         description = "rclone Google Drive mount service";
         after = [
           "network-online.target"
-          "chrony-first-sync.service"
+          "time-sync.target"
         ];
         wants = [
           "network-online.target"
-          "chrony-first-sync.service"
+          "time-sync.target"
         ];
         wantedBy = [ "default.target" ];
         serviceConfig = {
           ExecStart = "${pkgs.rclone}/bin/rclone mount ${username}: /mnt/google_drive/${username} --allow-other --vfs-cache-mode full --buffer-size 128M --vfs-read-ahead 512M --drive-chunk-size 64M --config /home/${username}/.config/rclone/rclone.conf";
-          ExecStartPre = "${pkgs.bash}/bin/bash -c '${pkgs.coreutils}/bin/mkdir -p /mnt/google_drive/${username} && ${pkgs.coreutils}/bin/chown ${username}:users /mnt/google_drive/${username} && for i in {1..30}; do ${pkgs.chrony}/bin/chronyc tracking && break; sleep 1; done'";
+          ExecStartPre = "${pkgs.bash}/bin/bash -c '${pkgs.coreutils}/bin/mkdir -p /mnt/google_drive/${username} && ${pkgs.coreutils}/bin/chown ${username}:users /mnt/google_drive/${username}'";
           ExecStop = "${pkgs.util-linux}/bin/umount -l /mnt/google_drive/${username}";
           Restart = "on-failure";
           RestartSec = "10s";


### PR DESCRIPTION
- replace default NTP pool servers with Japanese specific server
- add iburst option and enable RTC trimming for better synchronization
- create early hardware clock setting service to ensure proper time at boot
- add `fix-timezone-early` service to set correct timezone before chrony
- update time synchronization dependencies to use `time-sync.target`
- reorganize time configuration sections for better readability