### PR TITLE
💄style: unify terminology for update messages

### DIFF
--- a/home/programs/cli/shell.nix
+++ b/home/programs/cli/shell.nix
@@ -13,7 +13,7 @@
         in
         config.lib.dag.entryAfter [ "writeBoundary" ] ''
           echo ""
-          echo "updating sheldon plugins..."
+          echo "update sheldon plugins..."
           echo ""
           ${script}
         '';

--- a/home/programs/languages/go.nix
+++ b/home/programs/languages/go.nix
@@ -35,7 +35,7 @@
         in
         config.lib.dag.entryAfter [ "writeBoundary" ] ''
           echo ""
-          echo "sync go packages..."
+          echo "update go packages..."
           echo ""
           ${script}
           echo ""


### PR DESCRIPTION
- change `sync go packages` to `update go packages` to maintain consistent terminology across configuration files
- similarly update `updating sheldon plugins` to `update sheldon plugins` for consistency in verb tense and wording style