### PR TITLE
✨feat: enable steam local network game transfers

### DIFF
--- a/modules/programs/game.nix
+++ b/modules/programs/game.nix
@@ -3,10 +3,13 @@
   programs = {
     steam = {
       enable = true;
-      remotePlay = {
+      dedicatedServer = {
         openFirewall = true;
       };
-      dedicatedServer = {
+      localNetworkGameTransfers = {
+        openFirewall = true;
+      };
+      remotePlay = {
         openFirewall = true;
       };
     };


### PR DESCRIPTION
- add `localNetworkGameTransfers` configuration with firewall opened
- reorder steam configuration sections for better readability