### PR TITLE
🐞fix: complete font configuration for all font families

### DIFF
--- a/modules/desktop/fonts.nix
+++ b/modules/desktop/fonts.nix
@@ -7,8 +7,8 @@
       enable = true;
     };
     packages = with pkgs; [
-      noto-fonts-emoji
       plemoljp-nf
+      noto-fonts-emoji
     ];
     fontconfig = {
       enable = true;
@@ -17,6 +17,14 @@
       };
       defaultFonts = {
         serif = [
+          "plemoljp-nf"
+          "Noto Color Emoji"
+        ];
+        sansSerif = [
+          "plemoljp-nf"
+          "Noto Color Emoji"
+        ];
+        monospace = [
           "plemoljp-nf"
           "Noto Color Emoji"
         ];


### PR DESCRIPTION
- add missing `sansSerif` and monospace font configurations
- reorder font package declarations for consistency
- ensure `plemoljp-nf` and `Noto Color Emoji` are properly set as defaults for all font families