### PR TITLE
✨feat: add `fcitx5` with SKK input method for Japanese

### DIFF
--- a/home/config/fcitx5/conf/classicui.conf
+++ b/home/config/fcitx5/conf/classicui.conf
@@ -1,0 +1,2 @@
+ Theme=Nord-Dark
+ Font="plemoljp-nf 13"

--- a/home/config/fcitx5/conf/skk.conf
+++ b/home/config/fcitx5/conf/skk.conf
@@ -1,0 +1,31 @@
+# Rule
+Rule=default
+# Punctuation Style
+PunctuationStyle=Japanese
+# Initial Input Mode
+InitialInputMode=Hiragana
+# Page size
+PageSize=8
+# Candidate Layout
+Candidate Layout=Vertical
+# Return-key does not insert new line on commit
+EggLikeNewLine=True
+# Show Annotation
+ShowAnnotation=True
+# Candidate Key
+CandidateChooseKey="Qwerty Center Row (a,s,d,...)"
+# Number candidate of Triggers To Show Candidate Window
+NTriggersToShowCandWin=0
+
+[CandidatesPageUpKey]
+0=Page_Up
+
+[CandidatesPageDownKey]
+0=Next
+
+[CursorUp]
+0=Up
+
+[CursorDown]
+0=Down
+

--- a/home/config/fcitx5/config
+++ b/home/config/fcitx5/config
@@ -1,0 +1,83 @@
+[Hotkey]
+# Enumerate when press trigger key repeatedly
+EnumerateWithTriggerKeys=True
+# Enumerate Input Method Forward
+EnumerateForwardKeys=
+# Enumerate Input Method Backward
+EnumerateBackwardKeys=
+# Skip first input method while enumerating
+EnumerateSkipFirst=False
+# Time limit in milliseconds for triggering modifier key shortcuts
+ModifierOnlyKeyTimeout=250
+
+[Hotkey/TriggerKeys]
+0=Zenkaku_Hankaku
+1=Hangul
+2=Tools
+
+[Hotkey/AltTriggerKeys]
+0=Shift_L
+
+[Hotkey/EnumerateGroupForwardKeys]
+0=Super+space
+
+[Hotkey/EnumerateGroupBackwardKeys]
+0=Shift+Super+space
+
+[Hotkey/ActivateKeys]
+0=Hangul_Hanja
+
+[Hotkey/DeactivateKeys]
+0=Hangul_Romaja
+
+[Hotkey/PrevPage]
+0=Up
+
+[Hotkey/NextPage]
+0=Down
+
+[Hotkey/PrevCandidate]
+0=Shift+Tab
+
+[Hotkey/NextCandidate]
+0=Tab
+
+[Hotkey/TogglePreedit]
+0=Control+Alt+P
+
+[Behavior]
+# Active By Default
+ActiveByDefault=False
+# Reset state on Focus In
+resetStateWhenFocusIn=No
+# Share Input State
+ShareInputState=No
+# Show preedit in application
+PreeditEnabledByDefault=True
+# Show Input Method Information when switch input method
+ShowInputMethodInformation=True
+# Show Input Method Information when changing focus
+showInputMethodInformationWhenFocusIn=False
+# Show compact input method information
+CompactInputMethodInformation=True
+# Show first input method information
+ShowFirstInputMethodInformation=True
+# Default page size
+DefaultPageSize=5
+# Override Xkb Option
+OverrideXkbOption=False
+# Custom Xkb Option
+CustomXkbOption=
+# Force Enabled Addons
+EnabledAddons=
+# Force Disabled Addons
+DisabledAddons=
+# Preload input method to be used by default
+PreloadInputMethod=True
+# Allow input method in the password field
+AllowInputMethodForPassword=False
+# Show preedit text when typing password
+ShowPreeditForPassword=False
+# Interval of saving user data in minutes
+AutoSavePeriod=30
+

--- a/home/config/hypr/hyprland.conf
+++ b/home/config/hypr/hyprland.conf
@@ -80,8 +80,13 @@ dwindle {
 exec-once = hyprpaper
 exec-once = waybar
 exec-once = clipse -listen
+exec-once = fcitx5 -D
+exec-once = discord --start-minimized
+exec-once = steam -silent
 # env
 env = WLR_DRM_NO_ATOMIC,1
+env = QT_IM_MODULE,fcitx
+env = XMODIFIERS,@im=fcitx
 # windowrulev2
 windowrulev2 = float, class:FloatingVim
 windowrulev2 = float, class:FloatingClipse
@@ -104,7 +109,7 @@ bind = $mainMod, S, togglesplit
 bind = $mainMod SHIFT, Space, togglefloating
 bind = SUPER, L, exec, hyprlock
 bind = SUPER SHIFT, C, exec, hyprpicker -a -f hex
-bind = , XF86Tools, exec, ~/.local/bin/ime
+# bind = , XF86Tools, exec, ~/.local/bin/ime
 bind = CTRL SHIFT, Q, exec, ~/.local/bin/clipboard-history
 # move focus
 bind = $mainMod, H, movefocus, l

--- a/modules/core/i18n.nix
+++ b/modules/core/i18n.nix
@@ -1,6 +1,20 @@
+{ pkgs, ... }:
 {
   # i18n
   i18n = {
     defaultLocale = "en_US.UTF-8";
+    inputMethod = {
+      enable = true;
+      type = "fcitx5";
+      fcitx5 = {
+        addons = with pkgs; [
+          fcitx5-gtk
+          fcitx5-mozc
+          fcitx5-nord
+          fcitx5-skk
+        ];
+        waylandFrontend = true;
+      };
+    };
   };
 }


### PR DESCRIPTION
- add `fcitx5` configuration files with `Nord-Dark` theme
- configure SKK input method for Japanese typing
- setup autostart and environment variables in `Hyprland`
- add `fcitx5` and required addons (`mozc`, `skk`, `nord`) to Nix modules
- disable old IME toggle hotkey