### PR TITLE
🔧refactor: simplify fcitx5 input method trigger keys

### DIFF
--- a/home/config/fcitx5/config
+++ b/home/config/fcitx5/config
@@ -11,9 +11,8 @@ EnumerateSkipFirst=False
 ModifierOnlyKeyTimeout=250
 
 [Hotkey/TriggerKeys]
-0=Zenkaku_Hankaku
-1=Hangul
-2=Tools
+0=Tools
+1=Control+Control_R
 
 [Hotkey/AltTriggerKeys]
 0=Shift_L


### PR DESCRIPTION
- remove unnecessary trigger keys (`Zenkaku_Hankaku`, `Hangul`)
- keep only the essential `Tools` key
- add `Control+Control_R `as an alternative trigger combination
- this change makes input method switching more consistent and prevents accidental toggles from specialized keyboard keys