### PR TITLE
🐞fix: remove `pull_request_target` trigger to prevent infinite loop

### DIFF
--- a/.github/workflows/auto-merge-dependency-update-pr.yml
+++ b/.github/workflows/auto-merge-dependency-update-pr.yml
@@ -1,7 +1,5 @@
 name: Auto Merge Dependency Update PR
 on:
-  pull_request_target:
-    types: [opened, labeled, synchronize]
   workflow_run:
     workflows: ["Update Nix Flake Dependencies"]
     types: [completed]
@@ -11,9 +9,7 @@ permissions:
 jobs:
   find-pr:
     runs-on: ubuntu-latest
-    if: |
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
-      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'dependencies'))
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     outputs:
       pr_number: ${{ steps.find-pr.outputs.pr_number }}
       branch_name: ${{ steps.find-pr.outputs.branch_name }}
@@ -25,7 +21,32 @@ jobs:
         id: find-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: "if [ \"${{ github.event_name }}\" = \"pull_request_target\" ]; then\n  # Direct PR information from pull_request_target event\n  PR_NUMBER=\"${{ github.event.pull_request.number }}\"\n  HEAD_REF=\"${{ github.event.pull_request.head.ref }}\"\n  \n  echo \"Using PR from pull_request_target event: #$PR_NUMBER ($HEAD_REF)\"\n  echo \"pr_number=$PR_NUMBER\" >> $GITHUB_OUTPUT\n  echo \"branch_name=$HEAD_REF\" >> $GITHUB_OUTPUT\n  echo \"found=true\" >> $GITHUB_OUTPUT\nelse\n  # Search for PR when triggered by workflow_run\n  echo \"Searching for dependency update PRs...\"\n\n  # get recent PRs and filter for our criteria\n  PR_LIST=$(gh pr list --base main --limit 10 --json number,headRefName,labels --jq '.')\n  echo \"$PR_LIST\" > /tmp/pr_list.json\n\n  # extract matching PR with jq\n  MATCHING_PR=$(jq -r '[.[] |\n    select(.headRefName | startswith(\"auto-update/flake-lock/\")) |\n    select(.labels | map(.name) | any(. == \"dependencies\" or . == \"automated\")) |\n    {number: .number, headRefName: .headRefName}] | first // {}' /tmp/pr_list.json)\n\n  # check if we found a matching PR\n  if [[ $(echo \"$MATCHING_PR\" | jq 'has(\"number\")') == \"true\" ]]; then\n    PR_NUMBER=$(echo \"$MATCHING_PR\" | jq -r '.number')\n    HEAD_REF=$(echo \"$MATCHING_PR\" | jq -r '.headRefName')\n    echo \"PR #$PR_NUMBER ($HEAD_REF) is a valid dependency update PR\"\n    echo \"pr_number=$PR_NUMBER\" >> $GITHUB_OUTPUT\n    echo \"branch_name=$HEAD_REF\" >> $GITHUB_OUTPUT\n    echo \"found=true\" >> $GITHUB_OUTPUT\n  else\n    echo \"No matching PR found\"\n    echo \"found=false\" >> $GITHUB_OUTPUT\n  fi\nfi\n"
+        run: |
+          # Search for PR when triggered by workflow_run
+          echo "Searching for dependency update PRs..."
+
+          # get recent PRs and filter for our criteria
+          PR_LIST=$(gh pr list --base main --limit 10 --json number,headRefName,labels --jq '.')
+          echo "$PR_LIST" > /tmp/pr_list.json
+
+          # extract matching PR with jq
+          MATCHING_PR=$(jq -r '[.[] |
+            select(.headRefName | startswith("auto-update/flake-lock/")) |
+            select(.labels | map(.name) | any(. == "dependencies" or . == "automated")) |
+            {number: .number, headRefName: .headRefName}] | first // {}' /tmp/pr_list.json)
+
+          # check if we found a matching PR
+          if [[ $(echo "$MATCHING_PR" | jq 'has("number")') == "true" ]]; then
+            PR_NUMBER=$(echo "$MATCHING_PR" | jq -r '.number')
+            HEAD_REF=$(echo "$MATCHING_PR" | jq -r '.headRefName')
+            echo "PR #$PR_NUMBER ($HEAD_REF) is a valid dependency update PR"
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "branch_name=$HEAD_REF" >> $GITHUB_OUTPUT
+            echo "found=true" >> $GITHUB_OUTPUT
+          else
+            echo "No matching PR found"
+            echo "found=false" >> $GITHUB_OUTPUT
+          fi
   auto-approve-and-merge:
     runs-on: ubuntu-latest
     needs: find-pr


### PR DESCRIPTION
- remove `pull_request_target` from `auto-merge` workflow triggers
- this resolves self-referencing infinite loop where workflow waits for itself
- simplify condition logic to only handle workflow_run events
- PAT token usage ensures workflow_run events are properly triggered
- clean up dual-path PR detection logic to single workflow_run path