### PR TITLE
🐞fix: restore `.IGNORE` to prevent windows update errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,9 @@ MAKEFLAGS += --no-print-directory
 # not show command all
 .SILENT:
 
+# ignore errors all
+.IGNORE:
+
 #
 # unified targets
 #


### PR DESCRIPTION
- restore `.IGNORE` directive to make all recipe errors non-fatal
- prevents windows update process from stopping on command failures
- allows `winget/scoop` operations to continue even if some fail