### PR TITLE
✨feat: add `claude-code.nvim` plugin with keybindings

### DIFF
--- a/home/config/nvim/lua/plugins/tools/external/ai/claude_code_nvim.lua
+++ b/home/config/nvim/lua/plugins/tools/external/ai/claude_code_nvim.lua
@@ -1,0 +1,70 @@
+-- claude code plugin
+-- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>al)
+return {
+	{
+		"greggh/claude-code.nvim",
+		dependencies = {
+			"nvim-lua/plenary.nvim",
+		},
+		lazy = true,
+		cmd = {
+			"ClaudeCode",
+			"ClaudeCodeContinue",
+			"ClaudeCodeResume",
+			"ClaudeCodeVerbose",
+		},
+		config = function()
+			-- claude-code.nvim config
+			require("claude-code").setup({
+				-- Terminal window settings
+				window = {
+					split_ratio = 0.3, -- Percentage of screen for the terminal window (height for horizontal, width for vertical splits)
+					position = "rightbelow vsplit", -- Position of the window: "botright", "topleft", "vertical", "rightbelow vsplit", etc.
+					enter_insert = true, -- Whether to enter insert mode when opening Claude Code
+					hide_numbers = true, -- Hide line numbers in the terminal window
+					hide_signcolumn = true, -- Hide the sign column in the terminal window
+				},
+				-- File refresh settings
+				refresh = {
+					enable = true, -- Enable file change detection
+					updatetime = 100, -- updatetime when Claude Code is active (milliseconds)
+					timer_interval = 1000, -- How often to check for file changes (milliseconds)
+					show_notifications = true, -- Show notification when files are reloaded
+				},
+				-- Git project settings
+				git = {
+					use_git_root = true, -- Set CWD to git root when opening Claude Code (if in git project)
+				},
+				-- Shell-specific settings
+				shell = {
+					separator = "&&", -- Command separator used in shell commands
+					pushd_cmd = "pushd", -- Command to push directory onto stack (e.g., 'pushd' for bash/zsh, 'enter' for nushell)
+					popd_cmd = "popd", -- Command to pop directory from stack (e.g., 'popd' for bash/zsh, 'exit' for nushell)
+				},
+				-- Command settings
+				command = "claude", -- Command used to launch Claude Code
+				-- Command variants
+				command_variants = {
+					-- Conversation management
+					continue = "--continue", -- Resume the most recent conversation
+					resume = "--resume", -- Display an interactive conversation picker
+					-- Output options
+					verbose = "--verbose", -- Enable verbose logging with full turn-by-turn output
+				},
+				-- Keymaps
+				keymaps = {
+					toggle = {
+						normal = false, -- Normal mode keymap for toggling Claude Code, false to disable
+						terminal = false, -- Terminal mode keymap for toggling Claude Code, false to disable
+						variants = {
+							continue = false, -- Normal mode keymap for Claude Code with continue flag
+							verbose = false, -- Normal mode keymap for Claude Code with verbose flag
+						},
+					},
+					window_navigation = true, -- Enable window navigation keymaps (<C-h/j/k/l>)
+					scrolling = true, -- Enable scrolling keymaps (<C-f/b>) for page up/down
+				},
+			})
+		end,
+	},
+}

--- a/home/config/nvim/lua/plugins/tools/internal/which_key_nvim.lua
+++ b/home/config/nvim/lua/plugins/tools/internal/which_key_nvim.lua
@@ -55,6 +55,12 @@ return {
 					{ "<LEADER>ags", "<CMD>Gpchatnew split<CR>", desc = "gpchat: new split" },
 					{ "<LEADER>agt", "<CMD>Gpchatnew tabnew<CR>", desc = "gpchat: new tabnew" },
 					{ "<LEADER>agv", "<CMD>GpChatNew vsplit<CR>", desc = "gpchat: new vsplit" },
+					-- claude
+					{ "<LEADER>al", group = "claude" },
+					{ "<LEADER>alc", "<CMD>ClaudeCodeContinue<CR>", desc = "claude: continue conversation" },
+					{ "<LEADER>all", "<CMD>ClaudeCode<CR>", desc = "claude: toggle" },
+					{ "<LEADER>alr", "<CMD>ClaudeCodeResume<CR>", desc = "claude: resume conversation" },
+					{ "<LEADER>alv", "<CMD>ClaudeCodeVerbose<CR>", desc = "claude: verbose mode" },
 					-- buffers
 					{ "<LEADER>b", group = "buffers" },
 					{ "<LEADER>bb", "<CMD>BufferLineCyclePrev<CR>", desc = "buffer: switch to previous" },


### PR DESCRIPTION
- add `claude-code.nvim` plugin configuration for AI assistance
- configure terminal window settings with 30% split ratio
- enable file refresh detection with notifications
- set up git root detection for project context
- add keybindings under `<LEADER>al` for `Claude` commands:
  - `<LEADER>all`: toggle Claude Code
  - `<LEADER>alc`: continue conversation
  - `<LEADER>alr`: resume conversation picker
  - `<LEADER>alv`: verbose mode
- disable built-in keymaps in favor of which-key integration