### PR TITLE
🐞fix: remove font configuration from desktop fonts module

### DIFF
--- a/modules/desktop/fonts.nix
+++ b/modules/desktop/fonts.nix
@@ -12,24 +12,6 @@
     ];
     fontconfig = {
       enable = true;
-      subpixel = {
-        lcdfilter = "light";
-      };
-      defaultFonts = {
-        serif = [
-          "plemoljp-nf"
-          "Noto Color Emoji"
-        ];
-        sansSerif = [
-          "plemoljp-nf"
-          "Noto Color Emoji"
-        ];
-        monospace = [
-          "plemoljp-nf"
-          "Noto Color Emoji"
-        ];
-        emoji = [ "Noto Color Emoji" ];
-      };
     };
   };
 }


### PR DESCRIPTION
- remove subpixel LCD filter settings
- remove default font family configurations for serif, sans-serif, monospace, and emoji
- simplify fonts module to only handle font packages installation