### PR TITLE
🐞fix: add missing `font-sketchybar-app-fon` to brew casks

### DIFF
--- a/outputs/darwin/shared-modules/brew.nix
+++ b/outputs/darwin/shared-modules/brew.nix
@@ -23,6 +23,7 @@
       "easyfind"
       "font-sf-mono"
       "font-sf-pro"
+      "font-sketchybar-app-font"
       "github@beta"
       "google-drive"
       "hammerspoon"


### PR DESCRIPTION
- add `font-sketchybar-app-font` to homebrew cask list
- fix missing font dependency for sketchybar configuration