### PR TITLE
🔧refactor: modularize zsh configuration for better organization

### DIFF
--- a/configs/zsh/.zshenv
+++ b/configs/zsh/.zshenv
@@ -1,114 +1,32 @@
 #
-# .zshenv
+# .zshenv - zsh environment file
+# loaded for all zsh sessions (login, interactive, non-interactive)
 #
 
+# load .zshrc for interactive features
 [[ -f ./.zshrc ]] && . ./.zshrc
 
-# edited by yanosea
-
-# os
-export OS=$(uname)
-if [[ "$OS" = "Linux" ]]; then
-	if [[ -f /etc/os-release ]]; then
-		source /etc/os-release
-	fi
-fi
-# xdg config
-export XDG_CONFIG_HOME=$HOME/.config
-export XDG_CACHE_HOME=$HOME/.cache
-export XDG_DATA_HOME=$HOME/.local/share
-export XDG_STATE_HOME=$HOME/.local/state
-# editor
-if command -v nvim >/dev/null 2>&1; then
-	export VISUAL="nvim"
-	export EDITOR="nvim"
-elif command -v vim >/dev/null 2>&1; then
-	export VISUAL="vim"
-	export EDITOR="vim"
+# determine config directory
+if [[ -n "$ZDOTDIR" ]]; then
+	ZSHENV_DIR="$ZDOTDIR/env"
 else
-	export VISUAL="vi"
-	export EDITOR="vi"
+	ZSHENV_DIR="$HOME/.config/zsh/env"
 fi
-# browser
-if [[ "$OS" = "Linux" ]] && [[ -z "${WSL_DISTRO_NAME:-}" ]]; then
-	export BROWSER="vivaldi"
-fi
-# term
-export TERM=xterm-256color
-# histfiles
-## less
-export LESSHISTFILE=$XDG_STATE_HOME/less/.lesshst
-## node
-export NODE_REPL_HISTORY=$XDG_STATE_HOME/node/.node_repl_history
-# homebrew
-export HOMEBREW_NO_INSTALL_FROM_API=1
-# google drive
-export GOOGLE_DRIVE=$HOME/google_drive
-# path
-## local
-export PATH=$PATH:$HOME/.local/bin
-## zsh functions
-### common
-for file in $XDG_CONFIG_HOME/zsh/functions/*; do
-	if [ -f "$file" ]; then
-		source "$file"
-	fi
-done
-### wsl
-if [[ -n "${WSL_DISTRO_NAME:-}" ]]; then
-	export PATH=$PATH:/mnt/c/Windows
-	export PATH=$PATH:/mnt/c/Windows/System32
-	for file in $XDG_CONFIG_HOME/zsh/functions_win/*; do
-		source "$file"
-	done
-fi
-## go
-export GOPATH=$HOME/go
-export PATH=$PATH:$GOPATH/bin
-## cargo
-export PATH=$PATH:$HOME/.cargo/bin
-## pnpm
-export PNPM_HOME=$XDG_DATA_HOME/pnpm
-## python
-export PYENV_ROOT=$HOME/.pyenv
-export PATH=$PATH:$PYENV_ROOT/bin
-## ghq
-export GHQ_ROOT="$HOME"/ghq
-# credentials (sops-managed)
-## anthropic
-export ANTHROPIC_API_KEY=$(cat $XDG_DATA_HOME/sops/ANTHROPIC_API_KEY)
-## openai
-export OPENAI_API_KEY=$(cat $XDG_DATA_HOME/sops/OPENAI_API_KEY)
-## spotify
-export SPOTIFY_ID=$(cat $XDG_DATA_HOME/sops/SPOTIFY_ID)
-export SPOTIFY_SECRET=$(cat $XDG_DATA_HOME/sops/SPOTIFY_SECRET)
-export SPOTIFY_REDIRECT_URI=$(cat $XDG_DATA_HOME/sops/SPOTIFY_REDIRECT_URI)
-export SPOTIFY_REFRESH_TOKEN=$(cat $XDG_DATA_HOME/sops/SPOTIFY_REFRESH_TOKEN)
-## trello
-export TRELLO_USER=$(cat $XDG_DATA_HOME/sops/TRELLO_USER)
-export TRELLO_KEY=$(cat $XDG_DATA_HOME/sops/TRELLO_KEY)
-export TRELLO_TOKEN=$(cat $XDG_DATA_HOME/sops/TRELLO_TOKEN)
-# starship
-export STARSHIP_CONFIG=$XDG_CONFIG_HOME/starship/starship.toml
-# wakatime
-export WAKATIME_HOME=$XDG_CONFIG_HOME/wakatime
-# tavily
-export TAVILY_API_KEY=$(cat $XDG_DATA_HOME/sops/TAVILY_API_KEY)
-# darwin
-if [[ "$OS" = "Darwin" ]]; then
-	# model
-	export MAC_MODEL=$(system_profiler SPHardwareDataType | awk -F': ' '/Model Name/{print $2}')
-	# karabiner and goku
-	export GOKU_EDN_CONFIG_FILE=$XDG_CONFIG_HOME/karabiner/karabiner.edn
-	# libs
-	export CPATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
-	export LIBRARY_PATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
-	export C_INCLUDE_PATH=$CPATH
-	export CPLUS_INCLUDE_PATH=$CPATH
-	export CGO_ENABLED=0
-fi
-# yazi
-export YAZI_CONFIG_HOME=$XDG_CONFIG_HOME/yazi-alt
-# per-directory-history
-export HISTORY_BASE=$XDG_STATE_HOME/zsh/per-directory-history
-export PER_DIRECTORY_HISTORY_TOGGLE="^h"
+
+# system and basic environment
+source "$ZSHENV_DIR/system.zsh"
+source "$ZSHENV_DIR/editor.zsh"
+source "$ZSHENV_DIR/terminal.zsh"
+
+# paths and development environment
+source "$ZSHENV_DIR/paths.zsh"
+source "$ZSHENV_DIR/languages.zsh"
+
+# application-specific settings
+source "$ZSHENV_DIR/applications.zsh"
+source "$ZSHENV_DIR/credentials.zsh"
+
+# platform-specific settings
+source "$ZSHENV_DIR/darwin.zsh"
+source "$ZSHENV_DIR/linux.zsh"
+source "$ZSHENV_DIR/wsl.zsh"

--- a/configs/zsh/.zshrc
+++ b/configs/zsh/.zshrc
@@ -1,130 +1,20 @@
 #
-# .zshrc
+# .zshrc - zsh interactive shell configuration
+# loaded for interactive zsh sessions
 #
 
-# If not running interactively, don't do anything
-[[ $- != *i* ]] && return
-
-alias ls='ls --color=auto'
-PROMPT='[%n@%m %~]$ '
-
-# edited by yanosea
-
-# zellij
-if command -v zellij &>/dev/null; then
-	if [ -z "$INSIDE_ZELLIJ" ]; then
-		export INSIDE_ZELLIJ=1
-		exec zellij
-	fi
+# determine config directory
+if [[ -n "$ZDOTDIR" ]]; then
+    ZSHRC_DIR="$ZDOTDIR/rc"
+else
+    ZSHRC_DIR="$HOME/.config/zsh/rc"
 fi
-# homebrew
-if [[ "$OS" = "Darwin" ]]; then
-	eval $(/opt/homebrew/bin/brew shellenv)
-fi
-# sheldon
-eval "$(sheldon source)"
-# zoxide
-eval "$(zoxide init zsh)"
-# python
-eval "$(pyenv init -)"
-# starship
-eval "$(starship init zsh)"
-# fzf
-source <(fzf --zsh)
-# alias
-## cat alternative
-alias cat="$(which bat)"
-## cd dotfiles
-alias dot="cd $HOME/ghq/github.com/yanosea/yanoNixFiles"
-## fzf-make
-alias fm="fzf-make"
-alias fh="fzf-make history"
-alias fr="fzf-make repeat"
-## git(hub)
-alias gbp='git branch --merged | grep -v "\* $(git rev-parse --abbrev-ref HEAD)" | grep -v "^\s*$" | xargs -r git branch -d'
-alias ghd="gh-dash"
-alias gsf='git switch $(git branch -l | fzf | tr -d "* ")'
-alias gitgraph="git log --graph --all --oneline --decorate"
-# ls alternative
-alias ls="$(which lsd)"
-# nvim diff
-alias nvimdiff="$(which nvim) -d"
-# lazygit
-alias lg="lazygit"
-# reboot
-alias reboot="sudo systemctl reboot"
-# rm alternative
-alias rm="$(which trash)"
-# real rm
-alias rrm="$(which rm)"
-# rtty
-alias rtty='rtty run zellij --font "PlemolJP Console NF"'
-# shutdown
-alias shutdown="sudo systemctl poweroff"
-# systemctl-tui
-alias st="systemctl-tui"
-# tree alternative
-alias tree="$(which eza) --tree"
-# trello
-alias trello="trello-tui -board yanoBoard"
-# zmv
-alias zmv="noglob zmv -W"
-# z (cd previous directory)
-alias zz="z -"
-# make state directory
-if [[ ! -d "$XDG_STATE_HOME/zsh" ]]; then
-	mkdir -p "$XDG_STATE_HOME/zsh"
-fi
-# history
-HISTFILE=$XDG_STATE_HOME/zsh/.zhistory
-HISTSIZE=1000
-SAVEHIST=10000
-# zshopt
-## easy cd
-setopt auto_cd
-## choose completion with tab
-setopt auto_menu
-## add slash
-setopt auto_param_slash
-## completion in typing
-setopt complete_in_word
-## beep off
-setopt no_beep
-## correct typo
-setopt correct
-## enable glob
-setopt extendedglob nomatch
-## glob with dot
-setopt globdots
-## ignore history start with space
-setopt hist_ignore_space
-## disable C-d
-setopt IGNORE_EOF
-## show file type
-setopt list_types
-## completion with equal
-setopt magic_equal_subst
-## add slash
-setopt mark_dirs
-## notify background job status
-setopt notify
-## japanese file name
-setopt print_eight_bit
-## write history immediately
-setopt inc_append_history
-## append history
-setopt append_history
-## save time stamp in history
-setopt extended_history
-## ignore command start with space
-setopt hist_ignore_space
-# when to append history
-setopt inc_append_history_time
-## choose completion with arrow keys
-zstyle ":completion:*:default" menu select=2
-## upper case or lowercase
-zstyle ":completion:*" matcher-list "m:{a-z}={A-Z}"
-## zmv
-autoload -Uz zmv
-# AA
-show_random_aa
+
+# interactive shell configuration
+source "$ZSHRC_DIR/interactive.zsh"
+
+# external tools initialization
+source "$ZSHRC_DIR/tools.zsh"
+
+# aliases and shortcuts
+source "$ZSHRC_DIR/aliases.zsh"

--- a/configs/zsh/env/applications.zsh
+++ b/configs/zsh/env/applications.zsh
@@ -1,0 +1,15 @@
+#
+# application-specific environment settings
+#
+
+# google drive
+export GOOGLE_DRIVE=$HOME/google_drive
+# starship prompt
+export STARSHIP_CONFIG=$XDG_CONFIG_HOME/starship/starship.toml
+# wakatime
+export WAKATIME_HOME=$XDG_CONFIG_HOME/wakatime
+# yazi file manager
+export YAZI_CONFIG_HOME=$XDG_CONFIG_HOME/yazi-alt
+# per-directory-history
+export HISTORY_BASE=$XDG_STATE_HOME/zsh/per-directory-history
+export PER_DIRECTORY_HISTORY_TOGGLE="^h"

--- a/configs/zsh/env/credentials.zsh
+++ b/configs/zsh/env/credentials.zsh
@@ -1,0 +1,20 @@
+#
+# credentials environment settings (sops-managed)
+#
+
+# anthropic api
+export ANTHROPIC_API_KEY=$(cat $XDG_DATA_HOME/sops/ANTHROPIC_API_KEY)
+# openai api
+export OPENAI_API_KEY=$(cat $XDG_DATA_HOME/sops/OPENAI_API_KEY)
+# spotify api
+export SPOTIFY_ID=$(cat $XDG_DATA_HOME/sops/SPOTIFY_ID)
+export SPOTIFY_REDIRECT_URI=$(cat $XDG_DATA_HOME/sops/SPOTIFY_REDIRECT_URI)
+export SPOTIFY_REFRESH_TOKEN=$(cat $XDG_DATA_HOME/sops/SPOTIFY_REFRESH_TOKEN)
+export SPOTIFY_SECRET=$(cat $XDG_DATA_HOME/sops/SPOTIFY_SECRET)
+# tavily api
+export TAVILY_API_KEY=$(cat $XDG_DATA_HOME/sops/TAVILY_API_KEY)
+# trello api
+export TRELLO_KEY=$(cat $XDG_DATA_HOME/sops/TRELLO_KEY)
+export TRELLO_TOKEN=$(cat $XDG_DATA_HOME/sops/TRELLO_TOKEN)
+export TRELLO_USER=$(cat $XDG_DATA_HOME/sops/TRELLO_USER)
+

--- a/configs/zsh/env/darwin.zsh
+++ b/configs/zsh/env/darwin.zsh
@@ -1,0 +1,19 @@
+#
+# darwin (macOS) specific environment settings
+#
+
+if [[ "$OS" = "Darwin" ]]; then
+	# homebrew
+	export HOMEBREW_NO_INSTALL_FROM_API=1
+	# mac model detection
+	export MAC_MODEL=$(system_profiler SPHardwareDataType | awk -F': ' '/Model Name/{print $2}')
+	# karabiner and goku configuration
+	export GOKU_EDN_CONFIG_FILE=$XDG_CONFIG_HOME/karabiner/karabiner.edn
+	# development libraries and includes
+	export CPATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
+	export LIBRARY_PATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+	export C_INCLUDE_PATH=$CPATH
+	export CPLUS_INCLUDE_PATH=$CPATH
+	export CGO_ENABLED=0
+fi
+

--- a/configs/zsh/env/editor.zsh
+++ b/configs/zsh/env/editor.zsh
@@ -1,0 +1,15 @@
+#
+# editor environment settings
+#
+
+# editor preference: nvim > vim > vi
+if command -v nvim >/dev/null 2>&1; then
+	export VISUAL="nvim"
+	export EDITOR="nvim"
+elif command -v vim >/dev/null 2>&1; then
+	export VISUAL="vim"
+	export EDITOR="vim"
+else
+	export VISUAL="vi"
+	export EDITOR="vi"
+fi

--- a/configs/zsh/env/languages.zsh
+++ b/configs/zsh/env/languages.zsh
@@ -1,0 +1,15 @@
+#
+# programming languages environment settings
+#
+
+# go
+export GOPATH=$HOME/go
+export PATH=$PATH:$GOPATH/bin
+# node/pnpm
+export PNPM_HOME=$XDG_DATA_HOME/pnpm
+# python/pyenv
+export PYENV_ROOT=$HOME/.pyenv
+export PATH=$PATH:$PYENV_ROOT/bin
+# rust/cargo
+export PATH=$PATH:$HOME/.cargo/bin
+

--- a/configs/zsh/env/linux.zsh
+++ b/configs/zsh/env/linux.zsh
@@ -1,0 +1,8 @@
+#
+# linux (non-WSL) specific environment settings
+#
+
+# browser preference
+if [[ "$OS" = "Linux" ]] && [[ -z "${WSL_DISTRO_NAME:-}" ]]; then
+	export BROWSER="vivaldi"
+fi

--- a/configs/zsh/env/paths.zsh
+++ b/configs/zsh/env/paths.zsh
@@ -1,0 +1,15 @@
+#
+# path environment settings
+#
+
+# local bin path
+export PATH=$PATH:$HOME/.local/bin
+# zsh functions
+## common functions
+for file in $XDG_CONFIG_HOME/zsh/functions/*; do
+	if [ -f "$file" ]; then
+		source "$file"
+	fi
+done
+## ghq
+export GHQ_ROOT="$HOME"/ghq

--- a/configs/zsh/env/system.zsh
+++ b/configs/zsh/env/system.zsh
@@ -1,0 +1,17 @@
+#
+# system environment settings
+#
+
+# os detection
+export OS=$(uname)
+if [[ "$OS" = "Linux" ]]; then
+	if [[ -f /etc/os-release ]]; then
+		source /etc/os-release
+	fi
+fi
+# xdg base directory specification
+export XDG_CONFIG_HOME=$HOME/.config
+export XDG_CACHE_HOME=$HOME/.cache
+export XDG_DATA_HOME=$HOME/.local/share
+export XDG_STATE_HOME=$HOME/.local/state
+

--- a/configs/zsh/env/terminal.zsh
+++ b/configs/zsh/env/terminal.zsh
@@ -1,0 +1,12 @@
+#
+# terminal environment settings
+#
+
+# terminal configuration
+export TERM=xterm-256color
+# history file locations for various applications
+## less
+export LESSHISTFILE=$XDG_STATE_HOME/less/.lesshst
+## node
+export NODE_REPL_HISTORY=$XDG_STATE_HOME/node/.node_repl_history
+

--- a/configs/zsh/env/wsl.zsh
+++ b/configs/zsh/env/wsl.zsh
@@ -1,0 +1,13 @@
+#
+# WSL specific environment settings
+#
+
+# zsh functions
+# wsl-specific functions and paths
+if [[ -n "${WSL_DISTRO_NAME:-}" ]]; then
+	export PATH=$PATH:/mnt/c/Windows
+	export PATH=$PATH:/mnt/c/Windows/System32
+	for file in $XDG_CONFIG_HOME/zsh/functions_win/*; do
+		source "$file"
+	done
+fi

--- a/configs/zsh/rc/aliases.zsh
+++ b/configs/zsh/rc/aliases.zsh
@@ -1,0 +1,49 @@
+#
+# command aliases
+#
+
+# file operations
+## cat alternative
+alias cat="$(which bat)"
+## ls alternative
+alias ls="$(which lsd)"
+## tree alternative
+alias tree="$(which eza) --tree"
+## rm alternative (safe delete)
+alias rm="$(which trash)"
+## real rm
+alias rrm="$(which rm)"
+# navigation
+## cd to dotfiles
+alias dot="cd $HOME/ghq/github.com/yanosea/yanoNixFiles"
+## z (cd previous directory)
+alias zz="z -"
+# development tools
+## fzf-make
+alias fm="fzf-make"
+alias fh="fzf-make history"
+alias fr="fzf-make repeat"
+## git/github
+alias gbp='git branch --merged | grep -v "\* $(git rev-parse --abbrev-ref HEAD)" | grep -v "^\s*$" | xargs -r git branch -d'
+alias ghd="gh-dash"
+alias gsf='git switch $(git branch -l | fzf | tr -d "* ")'
+alias gitgraph="git log --graph --all --oneline --decorate"
+## editors
+alias nvimdiff="$(which nvim) -d"
+alias lg="lazygit"
+# system management
+## systemctl-tui
+alias st="systemctl-tui"
+## reboot
+alias reboot="sudo systemctl reboot"
+## shutdown
+alias shutdown="sudo systemctl poweroff"
+# applications
+## rtty terminal
+alias rtty='rtty run zellij --font "PlemolJP Console NF"'
+## trello
+alias trello="trello-tui -board yanoBoard"
+# utilities
+## zmv (bulk rename)
+alias zmv="noglob zmv -W"
+

--- a/configs/zsh/rc/interactive.zsh
+++ b/configs/zsh/rc/interactive.zsh
@@ -1,0 +1,62 @@
+#
+# interactive shell settings
+#
+
+# check if running interactively
+[[ $- != *i* ]] && return
+# default prompt (may be overridden by starship)
+alias ls='ls --color=auto'
+PROMPT='[%n@%m %~]$ '
+# zellij auto-start
+if command -v zellij &>/dev/null; then
+	if [ -z "$INSIDE_ZELLIJ" ]; then
+		export INSIDE_ZELLIJ=1
+		exec zellij
+	fi
+fi
+# create zsh state directory if it doesn't exist
+if [[ ! -d "$XDG_STATE_HOME/zsh" ]]; then
+	mkdir -p "$XDG_STATE_HOME/zsh"
+fi
+# history configuration
+HISTFILE=$XDG_STATE_HOME/zsh/.zhistory
+HISTSIZE=1000
+SAVEHIST=10000
+# completion dump file location
+export ZSH_COMPDUMP=$XDG_STATE_HOME/zsh/.zcompdump
+# zsh options
+## navigation
+setopt auto_cd          # easy cd
+setopt auto_param_slash # add slash
+setopt mark_dirs        # add slash to directories
+## completion
+setopt auto_menu         # choose completion with tab
+setopt complete_in_word  # completion in typing
+setopt magic_equal_subst # completion with equal
+setopt list_types        # show file type
+## interface
+setopt no_beep         # beep off
+setopt correct         # correct typo
+setopt print_eight_bit # japanese file name
+setopt notify          # notify background job status
+setopt IGNORE_EOF      # disable C-d
+## globbing
+setopt extendedglob nomatch # enable glob
+setopt globdots             # glob with dot
+## history
+setopt inc_append_history      # write history immediately
+setopt append_history          # append history
+setopt extended_history        # save time stamp in history
+setopt hist_ignore_space       # ignore history start with space
+setopt inc_append_history_time # when to append history
+# completion styling
+## choose completion with arrow keys
+zstyle ":completion:*:default" menu select=2
+## case insensitive completion
+zstyle ":completion:*" matcher-list "m:{a-z}={A-Z}"
+# autoloads
+autoload -Uz zmv
+autoload -Uz compinit && compinit -d "$ZSH_COMPDUMP"
+# display random ascii art
+show_random_aa
+

--- a/configs/zsh/rc/tools.zsh
+++ b/configs/zsh/rc/tools.zsh
@@ -1,0 +1,19 @@
+#
+# external tools initialization
+#
+
+# homebrew (macOS)
+if [[ "$OS" = "Darwin" ]]; then
+	eval $(/opt/homebrew/bin/brew shellenv)
+fi
+# shell plugin manager
+eval "$(sheldon source)"
+# directory jumping
+eval "$(zoxide init zsh)"
+# python version manager
+eval "$(pyenv init -)"
+# prompt theme
+eval "$(starship init zsh)"
+# fuzzy finder
+source <(fzf --zsh)
+

--- a/outputs/darwin/shared-modules/defaults.nix
+++ b/outputs/darwin/shared-modules/defaults.nix
@@ -2,11 +2,11 @@
 { hostname, username, ... }:
 let
   # import all defaults modules
-  global = import ./defaults/global.nix { inherit hostname username; };
-  dock = import ./defaults/dock.nix { inherit hostname username; };
-  finder = import ./defaults/finder.nix { inherit hostname username; };
-  input = import ./defaults/input.nix { inherit hostname username; };
-  ui = import ./defaults/ui.nix { inherit hostname username; };
+  global = import ./defaults/global.nix;
+  dock = import ./defaults/dock.nix;
+  finder = import ./defaults/finder.nix;
+  input = import ./defaults/input.nix;
+  ui = import ./defaults/ui.nix;
   system = import ./defaults/system.nix { inherit hostname username; };
 in
 {

--- a/outputs/darwin/shared-modules/defaults/dock.nix
+++ b/outputs/darwin/shared-modules/defaults/dock.nix
@@ -1,5 +1,4 @@
 # dock configuration
-{ hostname, username, ... }:
 {
   dock = {
     enable-spring-load-actions-on-all-items = true;

--- a/outputs/darwin/shared-modules/defaults/finder.nix
+++ b/outputs/darwin/shared-modules/defaults/finder.nix
@@ -1,5 +1,4 @@
 # finder configuration
-{ hostname, username, ... }:
 {
   finder = {
     AppleShowAllExtensions = true;

--- a/outputs/darwin/shared-modules/defaults/global.nix
+++ b/outputs/darwin/shared-modules/defaults/global.nix
@@ -1,5 +1,4 @@
 # global preferences and NSGlobalDomain
-{ hostname, username, ... }:
 {
   ".GlobalPreferences" = {
     "com.apple.mouse.scaling" = 17.0;

--- a/outputs/darwin/shared-modules/defaults/input.nix
+++ b/outputs/darwin/shared-modules/defaults/input.nix
@@ -1,5 +1,4 @@
 # input devices configuration (trackpad, mouse, keyboard)
-{ hostname, username, ... }:
 {
   magicmouse = {
     MouseButtonMode = "TwoButton";

--- a/outputs/darwin/shared-modules/defaults/ui.nix
+++ b/outputs/darwin/shared-modules/defaults/ui.nix
@@ -1,5 +1,4 @@
 # UI and window management configuration
-{ hostname, username, ... }:
 {
   ActivityMonitor = {
     IconType = 5;

--- a/outputs/darwin/yanoMac/home.nix
+++ b/outputs/darwin/yanoMac/home.nix
@@ -1,5 +1,10 @@
 # mac home configuration
-{ homePath, username, ... }:
+{
+  config,
+  homePath,
+  username,
+  ...
+}:
 {
   imports = [
     # darwin specific
@@ -12,7 +17,7 @@
     enableNixpkgsReleaseCheck = true;
     homeDirectory = "${homePath}/${username}";
     sessionVariables = {
-      ZDOTDIR = "${homePath}/${username}/.config/zsh";
+      ZDOTDIR = "${config.xdg.configHome}/zsh";
     };
     stateVersion = "24.05"; # DO NOT CHANGE
     username = username;

--- a/outputs/darwin/yanoMacBook/home.nix
+++ b/outputs/darwin/yanoMacBook/home.nix
@@ -1,5 +1,10 @@
 # macbook home configuration
-{ homePath, username, ... }:
+{
+  config,
+  homePath,
+  username,
+  ...
+}:
 {
   imports = [
     # darwin specific
@@ -12,7 +17,7 @@
     enableNixpkgsReleaseCheck = true;
     homeDirectory = "${homePath}/${username}";
     sessionVariables = {
-      ZDOTDIR = "${homePath}/${username}/.config/zsh";
+      ZDOTDIR = "${config.xdg.configHome}/zsh";
     };
     stateVersion = "24.05"; # DO NOT CHANGE
     username = username;

--- a/outputs/home-manager/hosts/yanoNixOs/cli/google-drive.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/cli/google-drive.nix
@@ -1,5 +1,10 @@
 # home google-drive module
-{ pkgs, username, ... }:
+{
+  config,
+  pkgs,
+  username,
+  ...
+}:
 let
   # rclone mount script
   rcloneMountScript = pkgs.writeShellScript "rclone-mount-google-drive" ''
@@ -24,14 +29,14 @@ let
     # cleanup existing mounts and prepare directory
     echo "preparing mount directory..."
     # attempt to unmount any existing mounts
-    ${pkgs.fuse}/bin/fusermount -uz "$HOME/google_drive" 2>/dev/null || true
-    ${pkgs.util-linux}/bin/umount -l "$HOME/google_drive" 2>/dev/null || true
+    ${pkgs.fuse}/bin/fusermount -uz "${config.home.homeDirectory}/google_drive" 2>/dev/null || true
+    ${pkgs.util-linux}/bin/umount -l "${config.home.homeDirectory}/google_drive" 2>/dev/null || true
     # wait briefly for unmount to complete
     ${pkgs.coreutils}/bin/sleep 2
     # force remove problematic directory if exists
-    ${pkgs.coreutils}/bin/rmdir "$HOME/google_drive" 2>/dev/null || ${pkgs.coreutils}/bin/rm -rf "$HOME/google_drive" 2>/dev/null || true
+    ${pkgs.coreutils}/bin/rmdir "${config.home.homeDirectory}/google_drive" 2>/dev/null || ${pkgs.coreutils}/bin/rm -rf "${config.home.homeDirectory}/google_drive" 2>/dev/null || true
     # recreate directory
-    ${pkgs.coreutils}/bin/mkdir -p "$HOME/google_drive"
+    ${pkgs.coreutils}/bin/mkdir -p "${config.home.homeDirectory}/google_drive"
     echo "mount directory ready"
     # wait for network with timeout
     echo "waiting for network connectivity..."
@@ -56,26 +61,26 @@ let
     # start rclone mount
     echo "starting rclone mount..."
     # start rclone mount
-    ${pkgs.rclone}/bin/rclone mount ${username}: "$HOME/google_drive" \
+    ${pkgs.rclone}/bin/rclone mount ${username}: "${config.home.homeDirectory}/google_drive" \
       --allow-other \
       --vfs-cache-mode full \
       --buffer-size 128M \
       --vfs-read-ahead 512M \
       --drive-chunk-size 64M \
-      --config "$HOME/.config/rclone/rclone.conf" \
+      --config "${config.xdg.configHome}/rclone/rclone.conf" \
       --log-level INFO \
-      --log-file "$HOME/.cache/rclone-mount.log"
+      --log-file "${config.xdg.cacheHome}/rclone-mount.log"
   '';
   # rclone unomnt script
   rcloneUnmountScript = pkgs.writeShellScript "rclone-unmount-google-drive" ''
     #!/bin/bash
     echo "stopping rclone mount..."
     # gracefully unmount
-    ${pkgs.fuse}/bin/fusermount -u "$HOME/google_drive" 2>/dev/null || true
+    ${pkgs.fuse}/bin/fusermount -u "${config.home.homeDirectory}/google_drive" 2>/dev/null || true
     # brief wait for unmount
     ${pkgs.coreutils}/bin/sleep 2
     # verify unmount completed
-    if ! ${pkgs.util-linux}/bin/mountpoint -q "$HOME/google_drive" 2>/dev/null; then
+    if ! ${pkgs.util-linux}/bin/mountpoint -q "${config.home.homeDirectory}/google_drive" 2>/dev/null; then
       echo "unmount completed"
     else
       echo "unmount may still be pending"

--- a/outputs/home-manager/hosts/yanoNixOs/gui/desktop.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/desktop.nix
@@ -1,5 +1,5 @@
 # home desktop module
-{ pkgs, ... }:
+{ config, pkgs, ... }:
 {
   # gtk
   gtk = {
@@ -31,21 +31,21 @@
   home = {
     file = {
       "wall_8K.png" = {
-        target = ".local/share/wallpapers/wall_8K.png";
+        target = "${config.xdg.dataHome}/wallpapers/wall_8K.png";
         source = pkgs.fetchurl {
           url = "https://raw.githubusercontent.com/hyprwm/Hyprland/778bdf730ff957521cc114d170bc82fc44b8be22/assets/wall_8K.png";
           sha256 = "sha256-VGwyAF73+1eKAFurOMOxi0dn9lbpwD/u5msWy+DS5kg=";
         };
       };
       "wall_anime_8K.png" = {
-        target = ".local/share/wallpapers/wall_anime_8K.png";
+        target = "${config.xdg.dataHome}/wallpapers/wall_anime_8K.png";
         source = pkgs.fetchurl {
           url = "https://raw.githubusercontent.com/hyprwm/Hyprland/778bdf730ff957521cc114d170bc82fc44b8be22/assets/wall_anime_8K.png";
           sha256 = "sha256-0H1sbQthf99ybSSli1DfGtQ+sm+MXDaoqJAGs43fx1U=";
         };
       };
       "wall_anime2_8K.png" = {
-        target = ".local/share/wallpapers/wall_anime2_8K.png";
+        target = "${config.xdg.dataHome}/wallpapers/wall_anime2_8K.png";
         source = pkgs.fetchurl {
           url = "https://raw.githubusercontent.com/hyprwm/Hyprland/778bdf730ff957521cc114d170bc82fc44b8be22/assets/wall_anime2_8K.png";
           sha256 = "sha256-PNuutAs1WT7vzQSPmvHUIdGcMpXG6Xjzt/pAokiYKTE=";

--- a/outputs/home-manager/shared-modules/cli/secrets.nix
+++ b/outputs/home-manager/shared-modules/cli/secrets.nix
@@ -7,7 +7,7 @@
   ...
 }:
 let
-  ageKeyFile = "${config.home.homeDirectory}/.config/sops/age/keys.txt";
+  ageKeyFile = "${config.xdg.configHome}/sops/age/keys.txt";
 in
 {
   # home

--- a/outputs/home-manager/shared-modules/languages/go.nix
+++ b/outputs/home-manager/shared-modules/languages/go.nix
@@ -22,7 +22,7 @@
           ];
           script = pkgs.writeShellScript "sync-go-packages" ''
             set -euo pipefail
-            export GOPATH="$HOME/go"
+            export GOPATH="${config.home.homeDirectory}/go"
             export GOBIN="$GOPATH/bin"
             export PATH="${pkgs.go}/bin:$GOBIN:$PATH"
             for pkg in ${builtins.concatStringsSep " " goPackages}; do

--- a/outputs/nixos/yanoNixOs/home.nix
+++ b/outputs/nixos/yanoNixOs/home.nix
@@ -1,5 +1,10 @@
 # nixos home configuration
-{ homePath, username, ... }:
+{
+  config,
+  homePath,
+  username,
+  ...
+}:
 {
   imports = [
     # host specific
@@ -14,7 +19,7 @@
     enableNixpkgsReleaseCheck = true;
     homeDirectory = "${homePath}/${username}";
     sessionVariables = {
-      ZDOTDIR = "${homePath}/${username}/.config/zsh";
+      ZDOTDIR = "${config.xdg.configHome}/zsh";
     };
     stateVersion = "24.05"; # DO NOT CHANGE
     username = username;

--- a/outputs/nixos/yanoNixOsWsl/home.nix
+++ b/outputs/nixos/yanoNixOsWsl/home.nix
@@ -1,5 +1,10 @@
 # nixos (wsl) home configuration
-{ homePath, username, ... }:
+{
+  config,
+  homePath,
+  username,
+  ...
+}:
 {
   imports = [
     # nixos specific
@@ -12,7 +17,7 @@
     enableNixpkgsReleaseCheck = true;
     homeDirectory = "${homePath}/${username}";
     sessionVariables = {
-      ZDOTDIR = "${homePath}/${username}/.config/zsh";
+      ZDOTDIR = "${config.xdg.configHome}/zsh";
     };
     stateVersion = "24.05"; # DO NOT CHANGE
     username = username;


### PR DESCRIPTION
- replace `ZDOTDIR` hardcoded paths with `${config.xdg.configHome}/zsh`
- replace `$HOME` environment variables with `${config.home.homeDirectory}`
- replace hardcoded `.config/`, `.cache/`, `.local/share/` paths with XDG variables
- update `age` key file path to use `${config.xdg.configHome}`
- update `rclone` configuration and log paths to use XDG variables
- update wallpaper target paths to use `${config.xdg.dataHome}`
- update `GOPATH` to use `${config.home.homeDirectory}`