### PR TITLE
✨feat: automate symbolic link creation with home-manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,15 +399,6 @@ endif
 # 	@echo ""
 # 	rclone config
 # 	@echo ""
-# 	@echo "$(COLOR_HEADER)make necessary symbolic links...$(COLOR_RESET)"
-# 	@echo ""
-# 	ln -s $$HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/installGitEmojiPrefixTemplate $$HOME/.local/bin/installGitEmojiPrefixTemplate
-# 	ln -s $$HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/install/installNixFmtPreCommitHook $$HOME/.local/bin/installNixFmtPreCommitHook
-# 	ln -s $$HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/nixos/clipboard-history $$HOME/.local/bin/clipboard-history
-# 	ln -s $$HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/nixos/ime $$HOME/.local/bin/ime
-# 	ln -s $$HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/nixos/check-recording $$HOME/.local/bin/check-recording
-# 	ln -s $$XDG_CONFIG_HOME/vim $$HOME/.vim
-# 	@echo ""
 # 	@echo "$(COLOR_HEADER)install skk dictionaries...$(COLOR_RESET)"
 # 	@echo ""
 # 	jisyo d
@@ -449,12 +440,9 @@ endif
 # 	@echo ""
 # 	@echo "$(COLOR_HEADER)make necessary symbolic links...$(COLOR_RESET)"
 # 	@echo ""
-# 	ln -s $$HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/installGitEmojiPrefixTemplate $$HOME/.local/bin/installGitEmojiPrefixTemplate
-# 	ln -s $$HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/install/installNixFmtPreCommitHook $$HOME/.local/bin/installNixFmtPreCommitHook
-# 	ln -s <WINDOWS_GOOGLE_DRIVE_PATH> $$HOME/google_drive
-# 	ln -s $$XDG_CONFIG_HOME/vim $$HOME/.vim
-# 	ln -s <WINDOWS_HOME_PATH> $$HOME/windows_home
 # 	ln -s <WINDOWS_WIN32YANK_PATH> $$HOME/.local/bin/win32yank.exe
+# 	ln -s <WINDOWS_GOOGLE_DRIVE_PATH> $$HOME/google_drive
+# 	ln -s <WINDOWS_HOME_PATH> $$HOME/windows_home
 # 	@echo ""
 # 	@echo "$(COLOR_HEADER)install skk dictionaries...$(COLOR_RESET)"
 # 	@echo ""
@@ -499,13 +487,6 @@ mac.init:
 # 	mkdir -p $$XDG_CONFIG_HOME/github-copilot
 # 	mkdir -p $$XDG_CONFIG_HOME/wakatime
 # 	@echo ""
-# 	@echo "$(COLOR_HEADER)make necessary symbolic links...$(COLOR_RESET)"
-# 	@echo ""
-# 	ln -s $$HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/installGitEmojiPrefixTemplate $$HOME/.local/bin/installGitEmojiPrefixTemplate
-# 	ln -s $$HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/install/installNixFmtPreCommitHook $$HOME/.local/bin/installNixFmtPreCommitHook
-# 	ln -s <GOOGLE_DRIVE_PATH> $$HOME/google_drive
-# 	ln -s $$XDG_CONFIG_HOME/vim $$HOME/.vim
-# 	@echo ""
 # 	@echo "$(COLOR_HEADER)install skk dictionaries...$(COLOR_RESET)"
 # 	@echo ""
 # 	jisyo d
@@ -548,13 +529,6 @@ mac.init:
 # 	mkdir -p $$XDG_STATE_HOME/zsh
 # 	mkdir -p $$XDG_CONFIG_HOME/github-copilot
 # 	mkdir -p $$XDG_CONFIG_HOME/wakatime
-# 	@echo ""
-# 	@echo "$(COLOR_HEADER)make necessary symbolic links...$(COLOR_RESET)"
-# 	@echo ""
-# 	ln -s $$HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/installGitEmojiPrefixTemplate $$HOME/.local/bin/installGitEmojiPrefixTemplate
-# 	ln -s $$HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/install/installNixFmtPreCommitHook $$HOME/.local/bin/installNixFmtPreCommitHook
-# 	ln -s <GOOGLE_DRIVE_PATH> $$HOME/google_drive
-# 	ln -s $$XDG_CONFIG_HOME/vim $$HOME/.vim
 # 	@echo ""
 # 	@echo "$(COLOR_HEADER)install skk dictionaries...$(COLOR_RESET)"
 # 	@echo ""

--- a/outputs/home-manager/hosts/yanoNixOs/cli/default.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/cli/default.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     ./google-drive.nix
+    ./symlinks.nix
     ./tools.nix
     ./wine.nix
   ];

--- a/outputs/home-manager/hosts/yanoNixOs/cli/symlinks.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/cli/symlinks.nix
@@ -1,0 +1,16 @@
+# home symlinks module
+{ lib, ... }:
+{
+  home = {
+    activation = {
+      linkNixosScripts = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        # create .local/bin directory if it doesn't exist
+        $DRY_RUN_CMD mkdir -p $HOME/.local/bin
+        # create symbolic links to nixos-specific scripts
+        $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/nixos/clipboard-history $HOME/.local/bin/clipboard-history
+        $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/nixos/ime $HOME/.local/bin/ime
+        $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/nixos/check-recording $HOME/.local/bin/check-recording
+      '';
+    };
+  };
+}

--- a/outputs/home-manager/hosts/yanoNixOsWsl/cli/default.nix
+++ b/outputs/home-manager/hosts/yanoNixOsWsl/cli/default.nix
@@ -1,0 +1,6 @@
+# yanoNixOsWsl specific cli modules for home
+{
+  imports = [
+    ./symlinks.nix
+  ];
+}

--- a/outputs/home-manager/hosts/yanoNixOsWsl/cli/symlinks.nix
+++ b/outputs/home-manager/hosts/yanoNixOsWsl/cli/symlinks.nix
@@ -1,0 +1,16 @@
+# home symlinks module
+{ lib, ... }:
+{
+  # nixos wsl specific symbolic links
+  home = {
+    activation = {
+      # this is just a memoization of the symlinks
+      linkWslSpecific = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        # WSL-specific symlinks (uncomment and adjust paths as needed)
+        # $DRY_RUN_CMD ln -sf <WINDOWS_WIN32YANK_PATH> $HOME/.local/bin/win32yank.exe
+        # $DRY_RUN_CMD ln -sf <WINDOWS_GOOGLE_DRIVE_PATH> $HOME/google_drive
+        # $DRY_RUN_CMD ln -sf <WINDOWS_HOME_PATH> $HOME/windows_home
+      '';
+    };
+  };
+}

--- a/outputs/home-manager/hosts/yanoNixOsWsl/default.nix
+++ b/outputs/home-manager/hosts/yanoNixOsWsl/default.nix
@@ -1,0 +1,6 @@
+# nixos (wsl) specific modules for home
+{
+  imports = [
+    ./cli
+  ];
+}

--- a/outputs/home-manager/os/darwin/cli/default.nix
+++ b/outputs/home-manager/os/darwin/cli/default.nix
@@ -2,5 +2,6 @@
 {
   imports = [
     ./desktop.nix
+    ./symlinks.nix
   ];
 }

--- a/outputs/home-manager/os/darwin/cli/symlinks.nix
+++ b/outputs/home-manager/os/darwin/cli/symlinks.nix
@@ -1,0 +1,14 @@
+# home symlinks module
+{ username, lib, ... }:
+{
+  home = {
+    activation = {
+      linkDarwinSpecific = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        # create google drive symlink (adjust path as needed)
+        if [ -d "$HOME/GoogleDrive/${username}" ]; then
+          $DRY_RUN_CMD ln -sf $HOME/GoogleDrive/${username} $HOME/google_drive
+        fi
+      '';
+    };
+  };
+}

--- a/outputs/home-manager/shared-modules/cli/default.nix
+++ b/outputs/home-manager/shared-modules/cli/default.nix
@@ -10,6 +10,7 @@
     ./media.nix
     ./shell.nix
     ./secrets.nix
+    ./symlinks.nix
     ./tools.nix
     ./xdg.nix
   ];

--- a/outputs/home-manager/shared-modules/cli/symlinks.nix
+++ b/outputs/home-manager/shared-modules/cli/symlinks.nix
@@ -1,0 +1,18 @@
+# home symlinks module
+{ lib, ... }:
+{
+  # home
+  home = {
+    activation = {
+      linkScripts = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        # create .local/bin directory if it doesn't exist
+        $DRY_RUN_CMD mkdir -p $HOME/.local/bin
+        # create symbolic links to scripts
+        $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/installGitEmojiPrefixTemplate $HOME/.local/bin/installGitEmojiPrefixTemplate
+        $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/install/installNixFmtPreCommitHook $HOME/.local/bin/installNixFmtPreCommitHook
+        # create vim configuration symlink
+        $DRY_RUN_CMD ln -sf $XDG_CONFIG_HOME/vim $HOME/.vim
+      '';
+    };
+  };
+}

--- a/outputs/nixos/yanoNixOsWsl/home.nix
+++ b/outputs/nixos/yanoNixOsWsl/home.nix
@@ -7,6 +7,8 @@
 }:
 {
   imports = [
+    # host specific
+    ../../home-manager/hosts/yanoNixOsWsl
     # nixos specific
     ../../home-manager/os/nixos
     # configs (dotfiles)


### PR DESCRIPTION
- migrate `Makefile`'s commented symbolic link creation to home-manager activation scripts for better automation and consistency
- add shared `symlinks` module for common scripts and `vim` config
- add platform-specific `symlinks` for `NixOS`, `Darwin`, and `WSL`
- remove redundant symlink creation from `Makefile` comments
- use `home.activation` for runtime link creation to avoid nix store issues