### PR TITLE
🐞fix: correct script path in symlinks configuration

### DIFF
--- a/outputs/home-manager/shared-modules/cli/symlinks.nix
+++ b/outputs/home-manager/shared-modules/cli/symlinks.nix
@@ -9,7 +9,7 @@
         $DRY_RUN_CMD mkdir -p $HOME/.local/bin
         # create symbolic links to scripts
         $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/installGitEmojiPrefixTemplate $HOME/.local/bin/installGitEmojiPrefixTemplate
-        $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/install/installNixFmtPreCommitHook $HOME/.local/bin/installNixFmtPreCommitHook
+        $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/installNixFmtPreCommitHook $HOME/.local/bin/installNixFmtPreCommitHook
         # create vim configuration symlink
         $DRY_RUN_CMD ln -sf $XDG_CONFIG_HOME/vim $HOME/.vim
       '';


### PR DESCRIPTION
- fix script path from `install/installNixFmtPreCommitHook` to `installNixFmtPreCommitHook` to match actual file location.