### PR TITLE
🧹chore(git): follow directory structure migration from `home/config` …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,20 @@
 # IGNORE DIRECTORY
-home/config/go/
-home/config/glzr/zebar/tmp-*
-home/config/lf/lf/
-home/config/scoop
-home/config/vim/autoload/
-home/config/vim/undo
-home/config/vim/viminfo
-home/config/wakatime/
-home/config/vim/plugged/
+configs/go/
+configs/glzr/zebar/tmp-*
+configs/lf/lf/
+configs/scoop
+configs/vim/autoload/
+configs/vim/undo
+configs/vim/viminfo
+configs/wakatime/
+configs/vim/plugged/
 .claude/
 .opencode/
 # IGNORE FILE
-home/config/gh/hosts.yml
-home/config/github-copilot/apps.json
-home/config/github-copilot/versions.json
-home/config/nvim/lazy-lock.json
+configs/gh/hosts.yml
+configs/github-copilot/apps.json
+configs/github-copilot/versions.json
+configs/nvim/lazy-lock.json
 result
 .DS_Store
 *.log


### PR DESCRIPTION
…to `configs`

- update ignore patterns to follow configuration directory migration
- adjust paths from `home/config/` to `configs/` to match recent restructuring
- align with commits `23439ad` and `fe69007` that moved config files to new location
- maintain existing ignore functionality for configuration file exclusions