### PR TITLE
✨feat(nvim): add zellij integration for claude code

### DIFF
--- a/configs/nvim/lua/plugins/tools/external/ai/claude_code_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/external/ai/claude_code_nvim.lua
@@ -12,6 +12,8 @@ return {
 			"ClaudeCodeContinue",
 			"ClaudeCodeResume",
 			"ClaudeCodeVerbose",
+			"ClaudeCodeSendBuffer",
+			"ClaudeCodeSendLine",
 		},
 		config = function()
 			-- claude-code.nvim config
@@ -65,6 +67,102 @@ return {
 					scrolling = true, -- Enable scrolling keymaps (<C-f/b>) for page up/down
 				},
 			})
+			-- Zellij integration functions
+			-- Session cache for pane ID (cleared when neovim restarts)
+			local cached_pane_id = nil
+			-- Function to find the Claude pane in Zellij
+			local function find_claude_pane()
+				-- Return cached pane ID if available
+				if cached_pane_id then
+					return cached_pane_id
+				end
+				-- First, try list-clients to find active Claude process
+				local handle = io.popen("zellij action list-clients")
+				if handle then
+					local result = handle:read("*a")
+					handle:close()
+					for line in result:gmatch("[^\r\n]+") do
+						if not line:match("CLIENT_ID") then
+							if line:match("claude") then
+								local _, pane_id, command = line:match("^%s*(%S+)%s+(%S+)%s+(.-)%s*$")
+								if pane_id and command and command:match("claude") then
+									cached_pane_id = pane_id
+									return pane_id
+								end
+							end
+						end
+					end
+				end
+				-- If list-clients doesn't show claude, ask user for pane id
+				local ps_handle = io.popen("ps aux | grep 'claude' | grep -v grep | head -1")
+				if ps_handle then
+					local ps_result = ps_handle:read("*a")
+					ps_handle:close()
+					if ps_result and ps_result ~= "" then
+						local pane_num = vim.fn.input("Enter Claude pane number (e.g. 1 for terminal_1): ")
+						if pane_num and pane_num ~= "" then
+							-- Convert number to terminal_X format
+							local pane_id = "terminal_" .. pane_num
+							-- Cache for this session
+							cached_pane_id = pane_id
+							return pane_id
+						end
+					end
+				end
+				vim.notify("No Claude pane found", vim.log.levels.WARN)
+				return nil
+			end
+			-- function to send text to Claude pane in Zellij
+			local function send_to_zellij_pane(text)
+				-- Check if we're in a zellij session
+				if not os.getenv("ZELLIJ") then
+					vim.notify("Not running in a Zellij session", vim.log.levels.ERROR)
+					return
+				end
+				-- Find Claude pane
+				local claude_pane = find_claude_pane()
+				if not claude_pane then
+					vim.notify("Could not find Claude pane. Make sure Claude is running.", vim.log.levels.ERROR)
+					return
+				end
+				-- Escape text only for single quotes (minimal escaping)
+				local escaped_text = text:gsub("'", "'\"'\"'")
+				-- Send text to Claude pane with Enter key
+				local script = string.format(
+					[[
+					zellij action move-focus right
+					sleep 0.1
+					zellij action write-chars '%s'
+					sleep 0.1
+					zellij action write-chars $'\r'
+					sleep 0.1
+					zellij action move-focus left
+				]],
+					escaped_text
+				)
+				local success = os.execute(script)
+				if success then
+					vim.notify("Text sent to Claude pane " .. claude_pane, vim.log.levels.INFO)
+				else
+					vim.notify("Failed to send text to Claude pane", vim.log.levels.ERROR)
+				end
+			end
+			-- Send current line to Claude pane
+			vim.api.nvim_create_user_command("ClaudeCodeSendLine", function()
+				local line = vim.fn.getline(".")
+				send_to_zellij_pane(line .. "\n")
+			end, { desc = "Send current line to Claude pane" })
+			-- Send buffer content to Claude pane (with size limit)
+			vim.api.nvim_create_user_command("ClaudeCodeSendBuffer", function()
+				local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+				local text = table.concat(lines, "\n")
+				-- Check buffer size (limit to reasonable size)
+				if #text > 5000 then
+					vim.notify("Buffer too large (" .. #text .. " chars). Max 5000 chars.", vim.log.levels.WARN)
+					return
+				end
+				send_to_zellij_pane(text .. "\n")
+			end, { desc = "Send buffer content to Claude pane" })
 		end,
 	},
 }

--- a/configs/nvim/lua/plugins/tools/internal/which_key_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/internal/which_key_nvim.lua
@@ -61,6 +61,9 @@ return {
 					{ "<LEADER>all", "<CMD>ClaudeCode<CR>", desc = "claude: toggle" },
 					{ "<LEADER>alr", "<CMD>ClaudeCodeResume<CR>", desc = "claude: resume conversation" },
 					{ "<LEADER>alv", "<CMD>ClaudeCodeVerbose<CR>", desc = "claude: verbose mode" },
+					-- claude × neovim × zellij integration
+					{ "<LEADER>als", "<CMD>ClaudeCodeSendBuffer<CR>", desc = "claude: send buffer to pane" },
+					{ "<LEADER>alS", "<CMD>ClaudeCodeSendLine<CR>", desc = "claude: send line to pane" },
 					-- buffers
 					{ "<LEADER>b", group = "buffers" },
 					{ "<LEADER>bb", "<CMD>BufferLineCyclePrev<CR>", desc = "buffer: switch to previous" },


### PR DESCRIPTION
- add `ClaudeCodeSendBuffer` command to send buffer content to claude pane
- add `ClaudeCodeSendLine` command to send current line to claude pane
- add zellij integration functions with pane discovery and text sending
- add keybindings `<LEADER>als` for buffer send and `<LEADER>alS` for line send
- implement session cache for claude pane id to improve performance
- add size limit validation for buffer content (max 5000 chars)