### PR TITLE
🐞fix(nvim): fix zellij claude code pane direction

### DIFF
--- a/configs/nvim/lua/plugins/editor/editing/comment_nvim.lua
+++ b/configs/nvim/lua/plugins/editor/editing/comment_nvim.lua
@@ -1,5 +1,5 @@
 -- comment utilizes the same keybinding as the default comment plugin
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>/)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>/)
 return {
 	{
 		"numToStr/Comment.nvim",

--- a/configs/nvim/lua/plugins/editor/motion/fuzzy_motion_vim.lua
+++ b/configs/nvim/lua/plugins/editor/motion/fuzzy_motion_vim.lua
@@ -1,5 +1,5 @@
 -- jump to fuzzy match word
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER><SPACE>)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER><SPACE>)
 return {
 	{
 		"yuki-yano/fuzzy-motion.vim",

--- a/configs/nvim/lua/plugins/editor/navigation/outline_nvim.lua
+++ b/configs/nvim/lua/plugins/editor/navigation/outline_nvim.lua
@@ -1,5 +1,5 @@
 -- a sidebar with a tree-like outline of symbols from the code, powered by LSP
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>lo)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>lo)
 return {
 	{
 		"hedyhli/outline.nvim",

--- a/configs/nvim/lua/plugins/languages/lsp/config/nvim_lspconfig.lua
+++ b/configs/nvim/lua/plugins/languages/lsp/config/nvim_lspconfig.lua
@@ -1,5 +1,5 @@
 -- lsp config
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER><SPACE>)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER><SPACE>)
 return {
 	{
 		"neovim/nvim-lspconfig",

--- a/configs/nvim/lua/plugins/tools/external/ai/avante_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/external/ai/avante_nvim.lua
@@ -1,5 +1,5 @@
 -- github copilot assistant plugin for avante.nvim
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>aa)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>aa)
 return {
 	{
 		"yetone/avante.nvim",

--- a/configs/nvim/lua/plugins/tools/external/ai/claude_code_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/external/ai/claude_code_nvim.lua
@@ -1,5 +1,5 @@
 -- claude code plugin
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>al)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>al)
 return {
 	{
 		"greggh/claude-code.nvim",
@@ -128,15 +128,16 @@ return {
 				-- Escape text only for single quotes (minimal escaping)
 				local escaped_text = text:gsub("'", "'\"'\"'")
 				-- Send text to Claude pane with Enter key
+				-- IMPORTANT : Claude pane must be positioned above the neovim pane in Zellij
 				local script = string.format(
 					[[
-					zellij action move-focus right
+					zellij action move-focus up
 					sleep 0.1
 					zellij action write-chars '%s'
 					sleep 0.1
 					zellij action write-chars $'\r'
 					sleep 0.1
-					zellij action move-focus left
+					zellij action move-focus down
 				]],
 					escaped_text
 				)

--- a/configs/nvim/lua/plugins/tools/external/ai/copilotchat_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/external/ai/copilotchat_nvim.lua
@@ -1,5 +1,5 @@
 -- github copilot chat for neovim
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>aC)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>aC)
 return {
 	{
 		"CopilotC-Nvim/CopilotChat.nvim",

--- a/configs/nvim/lua/plugins/tools/external/ai/gp_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/external/ai/gp_nvim.lua
@@ -1,5 +1,5 @@
 -- chatgpt for neovim
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>ag)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>ag)
 return {
 	{
 		"robitx/gp.nvim",

--- a/configs/nvim/lua/plugins/tools/external/denops_translate_vim.lua
+++ b/configs/nvim/lua/plugins/tools/external/denops_translate_vim.lua
@@ -1,5 +1,5 @@
 -- translate text
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>T)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>T)
 return {
 	{
 		"skanehira/denops-translate.vim",

--- a/configs/nvim/lua/plugins/tools/external/open_github_url_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/external/open_github_url_nvim.lua
@@ -1,5 +1,5 @@
 -- open github url under cursor (owner/repo)
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>gU)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>gU)
 return {
 	{
 		"tetzng/open-github-url.nvim",

--- a/configs/nvim/lua/plugins/tools/internal/grug_far_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/internal/grug_far_nvim.lua
@@ -1,5 +1,5 @@
 -- search and replace text
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>G)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>G)
 return {
 	{
 		"MagicDuck/grug-far.nvim",

--- a/configs/nvim/lua/plugins/tools/internal/nvim_tree.lua
+++ b/configs/nvim/lua/plugins/tools/internal/nvim_tree.lua
@@ -1,5 +1,5 @@
 -- file explorer
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>e)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>e)
 return {
 	{
 		"nvim-tree/nvim-tree.lua",

--- a/configs/nvim/lua/plugins/tools/internal/oil_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/internal/oil_nvim.lua
@@ -1,5 +1,5 @@
 -- buffer like netrw
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>o)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>o)
 return {
 	{
 		"stevearc/oil.nvim",

--- a/configs/nvim/lua/plugins/tools/internal/orgmode.lua
+++ b/configs/nvim/lua/plugins/tools/internal/orgmode.lua
@@ -1,5 +1,5 @@
 -- neovim org-mode
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>o, for grouping)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>o, for grouping)
 return {
 	{
 		"nvim-orgmode/orgmode",

--- a/configs/nvim/lua/plugins/tools/internal/telescope.lua
+++ b/configs/nvim/lua/plugins/tools/internal/telescope.lua
@@ -1,5 +1,5 @@
 -- ui for selecting files, searching, and more
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>s)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>s)
 return {
 	{
 		"nvim-telescope/telescope.nvim",

--- a/configs/nvim/lua/plugins/ui/components/alpha_nvim.lua
+++ b/configs/nvim/lua/plugins/ui/components/alpha_nvim.lua
@@ -1,5 +1,5 @@
 -- dashboard config
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>;)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>;)
 return {
 	{
 		"goolord/alpha-nvim",

--- a/configs/nvim/lua/plugins/ui/components/bufferline_nvim.lua
+++ b/configs/nvim/lua/plugins/ui/components/bufferline_nvim.lua
@@ -1,5 +1,5 @@
 -- bufferline config
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>b)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>b)
 return {
 	{
 		"akinsho/bufferline.nvim",

--- a/configs/nvim/lua/plugins/ui/components/noice_nvim.lua
+++ b/configs/nvim/lua/plugins/ui/components/noice_nvim.lua
@@ -1,5 +1,5 @@
 -- enhance the look of the editor
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>n)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>n)
 return {
 	{
 		"folke/noice.nvim",

--- a/configs/nvim/lua/plugins/ui/components/smear_cursor_nvim.lua
+++ b/configs/nvim/lua/plugins/ui/components/smear_cursor_nvim.lua
@@ -1,5 +1,5 @@
 -- cursor animation like Neovide
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>S)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>S)
 return {
 	{
 		"sphamba/smear-cursor.nvim",

--- a/configs/nvim/lua/plugins/ui/components/todo_comments_nvim.lua
+++ b/configs/nvim/lua/plugins/ui/components/todo_comments_nvim.lua
@@ -1,5 +1,5 @@
 -- highlight and search for todo comments
--- keymaps are set in lua/pulugins/tools/internal/which_key_nvim.lua (<LEADER>lT)
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>lT)
 return {
 	{
 		"folke/todo-comments.nvim",


### PR DESCRIPTION
- change `move-focus` direction from `right/left` to `up/down`
- add comment about claude pane positioning requirement
- improve zellij integration workflow for claude code plugin