### PR TITLE
🐞fix(lazygit): change pasteCommits keybinding from v to V

### DIFF
--- a/configs/lazygit/config.yml
+++ b/configs/lazygit/config.yml
@@ -207,7 +207,7 @@ keybinding:
     revertCommit: "t"
     cherryPickCopy: "c"
     cherryPickCopyRange: "C"
-    pasteCommits: "v"
+    pasteCommits: "V"
     tagCommit: "T"
     checkoutCommit: "<space>"
     resetCherryPick: "<c-R>"


### PR DESCRIPTION
- change `pasteCommits` keybinding from `v` to `V` in config.yml
- resolve issue where lowercase `v` key was not working properly