### PR TITLE
✨feat(nixos/hypr): add system control shortcuts with yad dialogs

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -101,6 +101,7 @@ bind = SUPER, Q, killactive
 bind = SUPER, E, exec, dolphin
 bind = SUPER, T, exec, wezterm
 bind = SUPER, B, exec, vivaldi
+bind = CTRL SHIFT, ESCAPE, exec, wezterm -e btop
 bind = SUPER SHIFT, S, exec, hyprshot -m region --clipboard-only
 bind = SUPER SHIFT, X, exec, hyprshot -m window -o ~/google_drive/pics -f "$(date +%Y-%m-%d-%H-%M-%S).png"
 bind = SUPER SHIFT, Q, exec, wf-recorder -a -o HDMI-A-1 --audio="alsa_output.usb-Roland_Rubix24-00.analog-surround-40.monitor" --audio-volume=1.5 -f ~/google_drive/movs/rec/$(date +%Y-%m-%d-%H-%M-%S)-HDMI-A-1.mp4

--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -100,6 +100,7 @@ $mainMod = ALT
 bind = SUPER, Q, killactive
 bind = SUPER, E, exec, dolphin
 bind = SUPER, T, exec, wezterm
+bind = SUPER, B, exec, vivaldi
 bind = SUPER SHIFT, S, exec, hyprshot -m region --clipboard-only
 bind = SUPER SHIFT, X, exec, hyprshot -m window -o ~/google_drive/pics -f "$(date +%Y-%m-%d-%H-%M-%S).png"
 bind = SUPER SHIFT, Q, exec, wf-recorder -a -o HDMI-A-1 --audio="alsa_output.usb-Roland_Rubix24-00.analog-surround-40.monitor" --audio-volume=1.5 -f ~/google_drive/movs/rec/$(date +%Y-%m-%d-%H-%M-%S)-HDMI-A-1.mp4

--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -165,3 +165,4 @@ bindm = $mainMod, mouse:273, resizewindow
 # system controls
 bind = SUPER SHIFT, R, exec, sh -c 'if yad --question --title="System Restart" --text="Are you sure you want to restart the system?" --button="No:1" --button="Yes:0" --width=400 --height=120; then systemctl reboot; fi'
 bind = SUPER SHIFT, D, exec, sh -c 'if yad --question --title="System Shutdown" --text="Are you sure you want to shutdown the system?" --button="No:1" --button="Yes:0" --width=400 --height=120; then systemctl poweroff; fi'
+bind = SUPER SHIFT, H, exec, sh -c 'hyprctl reload && dunstify "Hyprland" "Configuration reloaded!"'

--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -91,6 +91,8 @@ env = XMODIFIERS,@im=fcitx
 windowrulev2 = float, class:FloatingVim
 windowrulev2 = float, class:FloatingClipse
 windowrulev2 = immediate, class:^(cs2)$
+windowrulev2 = float, class:^(yad)$
+windowrulev2 = center, class:^(yad)$
 # bind
 # mainmod
 $mainMod = ALT
@@ -160,3 +162,6 @@ bind = $mainMod, mouse_up, workspace, e-1
 # move/resize windows
 bindm = $mainMod, mouse:272, movewindow
 bindm = $mainMod, mouse:273, resizewindow
+# system controls
+bind = SUPER SHIFT, R, exec, sh -c 'if yad --question --title="System Restart" --text="Are you sure you want to restart the system?" --button="No:1" --button="Yes:0" --width=400 --height=120; then systemctl reboot; fi'
+bind = SUPER SHIFT, D, exec, sh -c 'if yad --question --title="System Shutdown" --text="Are you sure you want to shutdown the system?" --button="No:1" --button="Yes:0" --width=400 --height=120; then systemctl poweroff; fi'

--- a/outputs/home-manager/hosts/yanoNixOs/gui/desktop.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/desktop.nix
@@ -72,6 +72,7 @@
         wl-clipboard
         wofi
         wofi-emoji
+        yad
       ]
     );
     pointerCursor = {


### PR DESCRIPTION
- add `yad` package to desktop environment
- add window rules to make `yad` dialogs float and center on screen
- add `SUPER + SHIFT + R` for system restart with `yad` confirmation
- add `SUPER + SHIFT + D` for system shutdown with `yad` confirmation