### PR TITLE
🐞fix(zellij): set default shell to zsh for function loading

### DIFF
--- a/configs/zellij/config.kdl
+++ b/configs/zellij/config.kdl
@@ -630,7 +630,7 @@ theme "everforest-dark"
 // Choose the path to the default shell that zellij will use for opening new panes
 // Default: $SHELL
 //
-// default_shell "fish"
+default_shell "zsh"
 // Choose the path to override cwd that zellij will use for opening new panes
 //
 // default_cwd "/tmp"


### PR DESCRIPTION
- add explicit `default_shell "zsh"` setting to `config.kdl`
- ensure `nixl` function is available in new panes when attaching
- fix issue where custom functions were not loaded in sessions