### PR TITLE
🐞fix(zsh): use absolute path for .zshrc loading

### DIFF
--- a/configs/zsh/.zshenv
+++ b/configs/zsh/.zshenv
@@ -4,7 +4,7 @@
 #
 
 # load .zshrc for interactive features
-[[ -f ./.zshrc ]] && . ./.zshrc
+[[ -f "$HOME/.zshrc" ]] && . "$HOME/.zshrc"
 
 # determine config directory
 if [[ -n "$ZDOTDIR" ]]; then


### PR DESCRIPTION
- change relative path `./.zshrc` to absolute path `$HOME/.zshrc`
- ensures `.zshrc` is loaded correctly in new zellij panes
- fixes issue where `nixl` function was not available in new sessions