### PR TITLE
✨feat(zsh): add zellij auto-attach functionality

### DIFF
--- a/configs/zsh/.zshrc
+++ b/configs/zsh/.zshrc
@@ -16,5 +16,11 @@ source "$ZSHRC_DIR/interactive.zsh"
 # external tools initialization
 source "$ZSHRC_DIR/tools.zsh"
 
+# zellij configuration
+source "$ZSHRC_DIR/zellij.zsh"
+
 # aliases and shortcuts
 source "$ZSHRC_DIR/aliases.zsh"
+
+# display random ascii art
+show_random_aa

--- a/configs/zsh/rc/interactive.zsh
+++ b/configs/zsh/rc/interactive.zsh
@@ -7,19 +7,6 @@
 # default prompt (may be overridden by starship)
 alias ls='ls --color=auto'
 PROMPT='[%n@%m %~]$ '
-# zellij auto-start
-if command -v zellij &>/dev/null && [ -z "$ZELLIJ" ]; then
-	# check for existing sessions (excluding EXITED)
-	sessions=$(zellij list-sessions 2>/dev/null | grep -v "EXITED")
-	if [ -n "$sessions" ]; then
-		# connect to the most recent session (first in list)
-		session_name=$(echo "$sessions" | head -1 | sed 's/\x1b\[[0-9;]*m//g' | cut -d' ' -f1)
-		exec zellij attach "$session_name"
-	else
-		# no sessions exist, create new
-		exec zellij
-	fi
-fi
 # create zsh state directory if it doesn't exist
 if [[ ! -d "$XDG_STATE_HOME/zsh" ]]; then
 	mkdir -p "$XDG_STATE_HOME/zsh"
@@ -63,5 +50,3 @@ zstyle ":completion:*" matcher-list "m:{a-z}={A-Z}"
 # autoloads
 autoload -Uz zmv
 autoload -Uz compinit && compinit -d "$ZSH_COMPDUMP"
-# display random ascii art
-show_random_aa

--- a/configs/zsh/rc/zellij.zsh
+++ b/configs/zsh/rc/zellij.zsh
@@ -1,0 +1,30 @@
+#
+# zellij configuration and auto-attach
+#
+
+# auto-attach to zellij session on interactive shell startup
+# only if we're in a terminal and not already in zellij
+if [[ -o interactive ]] && [[ -z "$ZELLIJ" ]] && [[ -n "$TERM" ]] && [[ "$TERM" != "dumb" ]]; then
+	# check if zellij is available
+	if command -v zellij &>/dev/null; then
+		# check for active sessions first
+		active_sessions=$(zellij list-sessions 2>/dev/null | grep -v "EXITED")
+		if [[ -n "$active_sessions" ]]; then
+			# connect to the most recent active session
+			session_name=$(echo "$active_sessions" | tail -1 | sed 's/\x1b\[[0-9;]*m//g' | cut -d' ' -f1)
+			exec zellij attach "$session_name"
+		fi
+
+		# check for EXITED sessions to resurrect
+		exited_sessions=$(zellij list-sessions 2>/dev/null | grep "EXITED")
+		if [[ -n "$exited_sessions" ]]; then
+			# connect to the most recent EXITED session (resurrect it)
+			session_name=$(echo "$exited_sessions" | tail -1 | sed 's/\x1b\[[0-9;]*m//g' | cut -d' ' -f1)
+			exec zellij attach "$session_name"
+		fi
+
+		# no sessions exist, create new
+		exec zellij
+	fi
+fi
+


### PR DESCRIPTION
- add `zellij.zsh` for automatic session connection
- remove zellij-related code from `interactive.zsh`
- implement priority-based session selection:
  1. active sessions → attach to most recent
  2. exited sessions → resurrect most recent
  3. no sessions → create new session
- add `show_random_aa` call to `.zshrc` for proper timing