### PR TITLE
🧹chore(cli): remove `aider-chat` package from `ai.nix`

### DIFF
--- a/outputs/home-manager/shared-modules/cli/ai.nix
+++ b/outputs/home-manager/shared-modules/cli/ai.nix
@@ -4,7 +4,6 @@
   # home
   home = {
     packages = with pkgs; [
-      aider-chat
       claude-code
       gemini-cli
       opencode


### PR DESCRIPTION
- remove `aider-chat` from home-manager packages as it is no longer used