### PR TITLE
✨feat(brew): add `homerow` application

### DIFF
--- a/outputs/darwin/shared-modules/brew.nix
+++ b/outputs/darwin/shared-modules/brew.nix
@@ -29,6 +29,7 @@
       "google-drive"
       "hammerspoon"
       "hiddenbar"
+      "homerow"
       "karabiner-elements"
       "libreoffice"
       "libreoffice-language-pack"


### PR DESCRIPTION
- add `homerow` to the list of cask applications in darwin shared modules