### PR TITLE
✨feat(nvim): add `telescope-undo` extension for undo history browsing

### DIFF
--- a/configs/nvim/lua/plugins/tools/internal/telescope.lua
+++ b/configs/nvim/lua/plugins/tools/internal/telescope.lua
@@ -13,6 +13,7 @@ return {
 				{ "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
 				{ "2kabhishek/nerdy.nvim", dependencies = { "folke/snacks.nvim" } },
 				"nvim-telescope/telescope-ui-select.nvim",
+				"debugloop/telescope-undo.nvim",
 			},
 		},
 		lazy = true,
@@ -107,6 +108,10 @@ return {
 						override_file_sorter = true,
 						case_mode = "smart_case",
 					},
+					undo = {
+						use_delta = true,
+						side_by_side = true,
+					},
 				},
 			})
 			-- load extensions
@@ -114,6 +119,7 @@ return {
 			require("telescope").load_extension("fzf")
 			require("telescope").load_extension("nerdy")
 			require("telescope").load_extension("ui-select")
+			require("telescope").load_extension("undo")
 		end,
 	},
 }

--- a/configs/nvim/lua/plugins/tools/internal/which_key_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/internal/which_key_nvim.lua
@@ -225,6 +225,7 @@ return {
 					{ "<LEADER>sr", "<CMD>Telescope oldfiles<CR>", desc = "search: recent file" },
 					{ "<LEADER>sR", "<CMD>Telescope registers<CR>", desc = "search: registers" },
 					{ "<LEADER>st", "<CMD>Telescope live_grep<CR>", desc = "search: text" },
+					{ "<LEADER>su", "<CMD>Telescope undo<CR>", desc = "search: undo" },
 					-- smear cursor
 					{ "<LEADER>S", "<CMD>SmearCursorToggle<CR>", desc = "smearcursor: toggle" },
 					-- terminal


### PR DESCRIPTION
- add `telescope-undo.nvim` plugin to telescope dependencies
- configure undo extension with delta view and side-by-side display
- add keybinding `<LEADER>su` to open undo history browser
- load undo extension in telescope setup