### PR TITLE
✨feat(nvim): add `nvim-spider` plugin for improved word motions

### DIFF
--- a/configs/nvim/lua/plugins/editor/editing/nvim_spider.lua
+++ b/configs/nvim/lua/plugins/editor/editing/nvim_spider.lua
@@ -1,0 +1,35 @@
+-- improve w, e, b motions
+return {
+	{
+		"chrisgrieser/nvim-spider",
+		lazy = true,
+		event = { "BufReadPost", "BufNewFile" },
+		config = function()
+			-- nvim-spider config
+			require("spider").setup({
+				skipInsignificantPunctuation = true,
+				consistentOperatorPending = true,
+				subwordMovement = true,
+			})
+			-- keymaps
+			vim.keymap.set(
+				{ "n", "o", "x" },
+				"w",
+				"<CMD>lua require('spider').motion('w')<CR>",
+				{ desc = "spider w", silent = true, noremap = true }
+			)
+			vim.keymap.set(
+				{ "n", "o", "x" },
+				"e",
+				"<CMD>lua require('spider').motion('e')<CR>",
+				{ desc = "spider e", silent = true, noremap = true }
+			)
+			vim.keymap.set(
+				{ "n", "o", "x" },
+				"b",
+				"<CMD>lua require('spider').motion('b')<CR>",
+				{ desc = "spider b", silent = true, noremap = true }
+			)
+		end,
+	},
+}


### PR DESCRIPTION
- add `nvim-spider` configuration for better `w`, `e`, `b` motions
- enable skipping insignificant punctuation
- enable consistent operator-pending mode behavior
- enable subword movement for camelCase/snake_case navigation
- set up keymaps to override default `w`, `e`, `b` motions