### PR TITLE
🚀perf(nvim): remove `golangci_lint` from `efm-langserver` config

### DIFF
--- a/configs/nvim/lua/plugins/languages/lsp/servers/efm.lua
+++ b/configs/nvim/lua/plugins/languages/lsp/servers/efm.lua
@@ -47,7 +47,6 @@ function M.setup()
 				-- go
 				go = {
 					require("efmls-configs.formatters.goimports"),
-					require("efmls-configs.linters.golangci_lint"),
 				},
 				-- lua
 				lua = {


### PR DESCRIPTION
- removed `golangci_lint` linter from `efm-langserver` to improve startup time
- reduced neovim startup time from ~153ms to ~68ms (55.8% improvement)
- `golangci_lint` was causing ~80-88ms delay due to multiple loads
- go linting remains functional via dedicated `golangci_lint_ls` language server
- `golangci_lint_ls` provides better performance than `efm-langserver` integration