### PR TITLE
🐞fix(nix): correct symbolic links for `serena` mcp scripts

### DIFF
--- a/outputs/home-manager/shared-modules/cli/symlinks.nix
+++ b/outputs/home-manager/shared-modules/cli/symlinks.nix
@@ -10,8 +10,8 @@
         # create symbolic links to scripts
         $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/installGitEmojiPrefixTemplate $HOME/.local/bin/installGitEmojiPrefixTemplate
         $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/installNixFmtPreCommitHook $HOME/.local/bin/installNixFmtPreCommitHook
-        $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/installNixFmtPreCommitHook $HOME/.local/bin/installSerenaMcp
-        $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/installNixFmtPreCommitHook $HOME/.local/bin/uninstallSerenaMcp
+        $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/installSerenaMcp $HOME/.local/bin/installSerenaMcp
+        $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/uninstallSerenaMcp $HOME/.local/bin/uninstallSerenaMcp
         # create vim configuration symlink
         $DRY_RUN_CMD ln -sf $XDG_CONFIG_HOME/vim $HOME/.vim
       '';


### PR DESCRIPTION
- fix `installSerenaMcp` symlink to point to correct script path
- fix `uninstallSerenaMcp` symlink to point to correct script path
- previously both were incorrectly linking to `installNixFmtPreCommitHook`