### PR TITLE
🧹chore(nix): update tuigreet package reference for nixpkgs compatibility

### DIFF
--- a/outputs/nixos/yanoNixOs/desktop/security.nix
+++ b/outputs/nixos/yanoNixOs/desktop/security.nix
@@ -32,7 +32,7 @@
       settings = {
         default_session = {
           command = ''
-            ${pkgs.greetd.tuigreet}/bin/tuigreet --time --cmd Hyprland
+            ${pkgs.tuigreet}/bin/tuigreet --time --cmd Hyprland
           '';
           user = username;
         };


### PR DESCRIPTION
- replace deprecated `greetd.tuigreet` with `tuigreet` to follow nixpkgs package renaming