### PR TITLE
✨feat(waybar): add window icon to hyprland window module

### DIFF
--- a/configs/waybar/config
+++ b/configs/waybar/config
@@ -37,7 +37,8 @@
     },
     "hyprland/window": {
       "max-length": 50,
-      "separate-outputs": true
+      "separate-outputs": true,
+      "format": "  {}",
     },
     "custom/recorder-hdmi": {
       "exec": "~/.local/bin/check-recording HDMI-A-1",
@@ -176,7 +177,8 @@
     },
     "hyprland/window": {
       "max-length": 50,
-      "separate-outputs": true
+      "separate-outputs": true,
+      "format": "  {}",
     },
     "custom/recorder-dp-3": {
       "exec": "~/.local/bin/check-recording DP-3",
@@ -315,7 +317,8 @@
     },
     "hyprland/window": {
       "max-length": 50,
-      "separate-outputs": true
+      "separate-outputs": true,
+      "format": "  {}",
     },
     "custom/recorder-dp-2": {
       "exec": "~/.local/bin/check-recording DP-2",


### PR DESCRIPTION
- add window icon to hyprland window format
- apply change to all three monitor configurations (HDMI-A-1, DP-3, DP-2)
- improves visual clarity by providing icon indicator for active window