### PR TITLE
✨feat(git): add OldTweetDeck repository to sync list

### DIFF
--- a/outputs/home-manager/shared-modules/cli/git.nix
+++ b/outputs/home-manager/shared-modules/cli/git.nix
@@ -7,6 +7,7 @@
       syncGitRepos =
         let
           repositories = [
+            "github.com/dimdenGD/OldTweetDeck"
             "github.com/tmux-plugins/tpm"
             "github.com/yanosea/cmf"
             "github.com/yanosea/jrp"


### PR DESCRIPTION
- added `github.com/dimdenGD/OldTweetDeck` to the list of repositories to sync