### PR TITLE
🐞fix(waybar): disable click events on workspace button gaps

### DIFF
--- a/configs/waybar/config
+++ b/configs/waybar/config
@@ -31,7 +31,7 @@
       "persistent-workspaces": {
          "HDMI-A-1": [1, 2, 3]
       },
-      "on-click": "hyprctl dispatch workspace name:{name}",
+      "on-click": "true",
       "on-scroll-up": "hyprctl dispatch workspace e+1",
       "on-scroll-down": "hyprctl dispatch workspace e-1"
     },
@@ -175,7 +175,7 @@
       "persistent-workspaces": {
          "DP-3": [4, 5, 6]
       },
-      "on-click": "hyprctl dispatch workspace name:{name}",
+      "on-click": "true",
       "on-scroll-up": "hyprctl dispatch workspace e+1",
       "on-scroll-down": "hyprctl dispatch workspace e-1"
     },
@@ -319,7 +319,7 @@
       "persistent-workspaces": {
          "DP-2": [7, 8, 9]
       },
-      "on-click": "hyprctl dispatch workspace name:{name}",
+      "on-click": "true",
       "on-scroll-up": "hyprctl dispatch workspace e+1",
       "on-scroll-down": "hyprctl dispatch workspace e-1"
     },


### PR DESCRIPTION
- replace `on-click` workspace dispatch with `true` command
- prevents unintended navigation to `name` workspace
- affects all three display outputs (HDMI-A-1, DP-3, DP-2)