### PR TITLE
🐞fix(nix): separate package installation from activation hooks

### DIFF
--- a/outputs/home-manager/shared-modules/cli/git.nix
+++ b/outputs/home-manager/shared-modules/cli/git.nix
@@ -24,48 +24,55 @@ in
       };
     };
   };
-  config = mkIf cfg.syncRepos {
-    # home
-    home = {
-      activation = {
-        syncGitRepos =
-          let
-            repositories = [
-              "github.com/dimdenGD/OldTweetDeck"
-              "github.com/tmux-plugins/tpm"
-              "github.com/yanosea/cmf"
-              "github.com/yanosea/jrp"
-              "github.com/yanosea/mindnum"
-              "github.com/yanosea/spotlike"
-              "github.com/yanosea/yanoNixFiles"
-              "github.com/yanosea/yanoPortfolio"
-            ];
-            script = pkgs.writeShellScript "sync-git-repos" ''
-              set -euo pipefail
-              export PATH=${pkgs.git}/bin:$PATH
-              for repo in ${builtins.concatStringsSep " " repositories}; do
-                ${pkgs.ghq}/bin/ghq get --update "$repo"
-              done
-            '';
-          in
-          config.lib.dag.entryAfter [ "writeBoundary" ] ''
-            echo ""
-            echo "sync git repos..."
-            echo ""
-            ${script}
-            echo ""
-          '';
+  config = mkMerge [
+    {
+      # home
+      home = {
+        packages = with pkgs; [
+          gh
+          gh-copilot
+          gh-dash
+          ghq
+          git-credential-oauth
+          git-lfs
+          github-cli
+          lazygit
+        ];
       };
-      packages = with pkgs; [
-        gh
-        gh-copilot
-        gh-dash
-        ghq
-        git-credential-oauth
-        git-lfs
-        github-cli
-        lazygit
-      ];
-    };
-  };
+    }
+    (mkIf cfg.syncRepos {
+      # home
+      home = {
+        activation = {
+          syncGitRepos =
+            let
+              repositories = [
+                "github.com/dimdenGD/OldTweetDeck"
+                "github.com/tmux-plugins/tpm"
+                "github.com/yanosea/cmf"
+                "github.com/yanosea/jrp"
+                "github.com/yanosea/mindnum"
+                "github.com/yanosea/spotlike"
+                "github.com/yanosea/yanoNixFiles"
+                "github.com/yanosea/yanoPortfolio"
+              ];
+              script = pkgs.writeShellScript "sync-git-repos" ''
+                set -euo pipefail
+                export PATH=${pkgs.git}/bin:$PATH
+                for repo in ${builtins.concatStringsSep " " repositories}; do
+                  ${pkgs.ghq}/bin/ghq get --update "$repo"
+                done
+              '';
+            in
+            config.lib.dag.entryAfter [ "writeBoundary" ] ''
+              echo ""
+              echo "sync git repos..."
+              echo ""
+              ${script}
+              echo ""
+            '';
+        };
+      };
+    })
+  ];
 }

--- a/outputs/home-manager/shared-modules/cli/shell.nix
+++ b/outputs/home-manager/shared-modules/cli/shell.nix
@@ -26,6 +26,7 @@ in
   };
   config = mkMerge [
     {
+      # home
       home = {
         packages = with pkgs; [
           inshellisense
@@ -37,120 +38,123 @@ in
           zsh
         ];
       };
-      programs.zsh = {
-        enable = true;
-        initContent = ''
-          # nix latest functions
-          nix-latest() {
-            # show help if no arguments provided
-            if [ $# -eq 0 ]; then
-              nix-latest help
-              return 0
-            fi
-            # check subcommand
-            case "$1" in
-              # package execution
-              run|shell)
-                shift
-                local cmd="nix shell"
-                for pkg in "$@"; do
-                  cmd="$cmd 'github:nixos/nixpkgs/master#$pkg'"
-                done
-                eval "$cmd"
-                ;;
-              # search packages
-              search)
-                shift
-                nix search "github:nixos/nixpkgs/master" "$@"
-                ;;
-              # development environment
-              develop|dev)
-                shift
-                if [ $# -eq 1 ]; then
-                  nix develop "github:nixos/nixpkgs/master#$1"
-                else
-                  echo -e "[31merror: develop accepts only one package[0m" >&2
+      # programs
+      programs = {
+        zsh = {
+          enable = true;
+          initContent = ''
+            # nix latest functions
+            nix-latest() {
+              # show help if no arguments provided
+              if [ $# -eq 0 ]; then
+                nix-latest help
+                return 0
+              fi
+              # check subcommand
+              case "$1" in
+                # package execution
+                run|shell)
+                  shift
+                  local cmd="nix shell"
+                  for pkg in "$@"; do
+                    cmd="$cmd 'github:nixos/nixpkgs/master#$pkg'"
+                  done
+                  eval "$cmd"
+                  ;;
+                # search packages
+                search)
+                  shift
+                  nix search "github:nixos/nixpkgs/master" "$@"
+                  ;;
+                # development environment
+                develop|dev)
+                  shift
+                  if [ $# -eq 1 ]; then
+                    nix develop "github:nixos/nixpkgs/master#$1"
+                  else
+                    echo -e "[31merror: develop accepts only one package[0m" >&2
+                    return 1
+                  fi
+                  ;;
+                # build package
+                build)
+                  shift
+                  local cmd="nix build"
+                  for pkg in "$@"; do
+                    cmd="$cmd 'github:nixos/nixpkgs/master#$pkg'"
+                  done
+                  eval "$cmd"
+                  ;;
+                # run once
+                run-once)
+                  shift
+                  if [ $# -eq 1 ]; then
+                    nix run "github:nixos/nixpkgs/master#$1"
+                  else
+                    echo -e "[31merror: run-once accepts only one package[0m" >&2
+                    return 1
+                  fi
+                  ;;
+                # show package info
+                show|info)
+                  shift
+                  if [ $# -eq 1 ]; then
+                    nix show-derivation "github:nixos/nixpkgs/master#$1"
+                  else
+                    echo -e "[31merror: show accepts only one package[0m" >&2
+                    return 1
+                  fi
+                  ;;
+                # evaluate expression
+                eval)
+                  shift
+                  nix eval "github:nixos/nixpkgs/master#$*"
+                  ;;
+                # flake operations
+                flake)
+                  shift
+                  nix flake "$@" "github:nixos/nixpkgs/master"
+                  ;;
+                # show build log
+                log)
+                  shift
+                  if [ $# -eq 1 ]; then
+                    nix log "github:nixos/nixpkgs/master#$1"
+                  else
+                    echo -e "[31merror: log accepts only one package[0m" >&2
+                    return 1
+                  fi
+                  ;;
+                # show help
+                help|-h|--help)
+                  echo "nix-latest - use latest nixpkgs (master branch)"
+                  echo ""
+                  echo "usage:"
+                  echo "  nix-latest run <pkg>       - run package in shell"
+                  echo "  nix-latest search <term>   - search packages"
+                  echo "  nix-latest develop <pkg>   - enter development shell"
+                  echo "  nix-latest build <pkg>     - build package"
+                  echo "  nix-latest run-once <pkg>  - run package once"
+                  echo "  nix-latest show <pkg>      - show package info"
+                  echo "  nix-latest eval <expr>     - evaluate expression"
+                  echo "  nix-latest log <pkg>       - show build log"
+                  echo "  nix-latest flake <cmd>     - flake commands"
+                  echo "  nix-latest help            - show this help"
+                  ;;
+                # unknown subcommand error
+                *)
+                  echo -e "[31merror: unknown subcommand '$1'[0m" >&2
+                  echo "run 'nix-latest help' for usage information" >&2
                   return 1
-                fi
-                ;;
-              # build package
-              build)
-                shift
-                local cmd="nix build"
-                for pkg in "$@"; do
-                  cmd="$cmd 'github:nixos/nixpkgs/master#$pkg'"
-                done
-                eval "$cmd"
-                ;;
-              # run once
-              run-once)
-                shift
-                if [ $# -eq 1 ]; then
-                  nix run "github:nixos/nixpkgs/master#$1"
-                else
-                  echo -e "[31merror: run-once accepts only one package[0m" >&2
-                  return 1
-                fi
-                ;;
-              # show package info
-              show|info)
-                shift
-                if [ $# -eq 1 ]; then
-                  nix show-derivation "github:nixos/nixpkgs/master#$1"
-                else
-                  echo -e "[31merror: show accepts only one package[0m" >&2
-                  return 1
-                fi
-                ;;
-              # evaluate expression
-              eval)
-                shift
-                nix eval "github:nixos/nixpkgs/master#$*"
-                ;;
-              # flake operations
-              flake)
-                shift
-                nix flake "$@" "github:nixos/nixpkgs/master"
-                ;;
-              # show build log
-              log)
-                shift
-                if [ $# -eq 1 ]; then
-                  nix log "github:nixos/nixpkgs/master#$1"
-                else
-                  echo -e "[31merror: log accepts only one package[0m" >&2
-                  return 1
-                fi
-                ;;
-              # show help
-              help|-h|--help)
-                echo "nix-latest - use latest nixpkgs (master branch)"
-                echo ""
-                echo "usage:"
-                echo "  nix-latest run <pkg>       - run package in shell"
-                echo "  nix-latest search <term>   - search packages"
-                echo "  nix-latest develop <pkg>   - enter development shell"
-                echo "  nix-latest build <pkg>     - build package"
-                echo "  nix-latest run-once <pkg>  - run package once"
-                echo "  nix-latest show <pkg>      - show package info"
-                echo "  nix-latest eval <expr>     - evaluate expression"
-                echo "  nix-latest log <pkg>       - show build log"
-                echo "  nix-latest flake <cmd>     - flake commands"
-                echo "  nix-latest help            - show this help"
-                ;;
-              # unknown subcommand error
-              *)
-                echo -e "[31merror: unknown subcommand '$1'[0m" >&2
-                echo "run 'nix-latest help' for usage information" >&2
-                return 1
-                ;;
-            esac
-          }
-          # short version
-          nixl() {
-            nix-latest "$@"
-          }
-        '';
+                  ;;
+              esac
+            }
+            # short version
+            nixl() {
+              nix-latest "$@"
+            }
+          '';
+        };
       };
     }
     (mkIf cfg.updateSheldonPlugins {

--- a/outputs/home-manager/shared-modules/languages/go.nix
+++ b/outputs/home-manager/shared-modules/languages/go.nix
@@ -24,57 +24,64 @@ in
       };
     };
   };
-  config = mkIf cfg.syncPackages {
-    # home
-    home = {
-      activation = {
-        syncGoPackages =
-          let
-            goPackages = [
-              "github.com/arrow2nd/jisyo@latest"
-              "github.com/giannimassi/trello-tui@latest"
-              "github.com/koki-develop/clive@latest"
-              "github.com/nao1215/gup@latest"
-              "github.com/sheepla/longgopher@latest"
-              "github.com/sheepla/og@latest"
-              "github.com/skanehira/rtty@latest"
-              "github.com/Songmu/gocredits/cmd/gocredits@latest"
-              "github.com/wadey/gocovmerge@latest"
-              "github.com/yanosea/jrp/v2/app/presentation/api/jrp-server@latest"
-              "github.com/yanosea/jrp/v2/app/presentation/cli/jrp@latest"
-              "github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum@latest"
-            ];
-            script = pkgs.writeShellScript "sync-go-packages" ''
-              set -euo pipefail
-              export GOPATH="${config.home.homeDirectory}/go"
-              export GOBIN="$GOPATH/bin"
-              export PATH="${pkgs.go}/bin:$GOBIN:$PATH"
-              for pkg in ${builtins.concatStringsSep " " goPackages}; do
-                ${pkgs.go}/bin/go install "$pkg"
-              done
-              if [ -x "$GOBIN/gup" ]; then
-                echo "found gup at $GOBIN/gup, running update..."
-                "$GOBIN/gup" update
-              fi
-            '';
-          in
-          config.lib.dag.entryAfter [ "writeBoundary" ] ''
-            echo ""
-            echo "update go packages..."
-            echo ""
-            ${script}
-            echo ""
-          '';
+  config = mkMerge [
+    {
+      # home
+      home = {
+        packages = with pkgs; [
+          cobra-cli
+          go-swag
+          go
+          goreleaser
+          gotests
+          gotools
+          mockgen
+        ];
       };
-      packages = with pkgs; [
-        cobra-cli
-        go-swag
-        go
-        goreleaser
-        gotests
-        gotools
-        mockgen
-      ];
-    };
-  };
+    }
+    (mkIf cfg.syncPackages {
+      # home
+      home = {
+        activation = {
+          syncGoPackages =
+            let
+              goPackages = [
+                "github.com/arrow2nd/jisyo@latest"
+                "github.com/giannimassi/trello-tui@latest"
+                "github.com/koki-develop/clive@latest"
+                "github.com/nao1215/gup@latest"
+                "github.com/sheepla/longgopher@latest"
+                "github.com/sheepla/og@latest"
+                "github.com/skanehira/rtty@latest"
+                "github.com/Songmu/gocredits/cmd/gocredits@latest"
+                "github.com/wadey/gocovmerge@latest"
+                "github.com/yanosea/jrp/v2/app/presentation/api/jrp-server@latest"
+                "github.com/yanosea/jrp/v2/app/presentation/cli/jrp@latest"
+                "github.com/yanosea/mindnum/v2/app/presentation/cli/mindnum@latest"
+              ];
+              script = pkgs.writeShellScript "sync-go-packages" ''
+                set -euo pipefail
+                export GOPATH="${config.home.homeDirectory}/go"
+                export GOBIN="$GOPATH/bin"
+                export PATH="${pkgs.go}/bin:$GOBIN:$PATH"
+                for pkg in ${builtins.concatStringsSep " " goPackages}; do
+                  ${pkgs.go}/bin/go install "$pkg"
+                done
+                if [ -x "$GOBIN/gup" ]; then
+                  echo "found gup at $GOBIN/gup, running update..."
+                  "$GOBIN/gup" update
+                fi
+              '';
+            in
+            config.lib.dag.entryAfter [ "writeBoundary" ] ''
+              echo ""
+              echo "update go packages..."
+              echo ""
+              ${script}
+              echo ""
+            '';
+        };
+      };
+    })
+  ];
 }


### PR DESCRIPTION
- move package definitions outside of conditional blocks in `git.nix` and `go.nix`
- ensure packages are always installed regardless of `EXPERIMENTAL_MODE` setting
- only network operations (repo sync, package updates) are now disabled in experimental mode
- fix issue where `lazygit` and other tools became unavailable after `make experiment`