### PR TITLE
🔧refactor(claude): change Serena MCP from user to project scope

### DIFF
--- a/ops/scripts/common/installSerenaMcp
+++ b/ops/scripts/common/installSerenaMcp
@@ -16,13 +16,12 @@ show_help() {
 	echo "  -h, --help    Display this help message"
 	echo ""
 	echo -e "${YELLOW}Description:${CLEAR}"
-	echo "  This script installs Serena MCP Server for the current project."
-	echo "  Serena is an IDE assistant that helps with code understanding and development."
+	echo "  This script installs Serena MCP Server for the current project's Claude Code configuration."
 	echo ""
 	echo -e "${YELLOW}What it does:${CLEAR}"
-	echo "  - Adds Serena MCP server to Claude Code"
-	echo "  - Configures it with IDE assistant context"
-	echo "  - Sets up the project path automatically"
+	echo "  - Adds Serena MCP Server to the current project only"
+	echo "  - Configures it with IDE assistant context and project path"
+	echo "  - Does not affect global or other project configurations"
 	echo ""
 	echo -e "${YELLOW}After installation:${CLEAR}"
 	echo "  Run ${GREEN}/mcp__serena__initial_instructions${CLEAR} in Claude Code to get started"
@@ -55,7 +54,7 @@ if ! command -v uvx &>/dev/null; then
 fi
 
 # confirm with user
-echo -e -n "Do you want to install Serena MCP Server for the current project? [y/N] "
+echo -e -n "Do you want to install Serena MCP Server to this project? [y/N] "
 read -r response
 if [[ ! "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
 	echo -e "${YELLOW}Installation aborted${CLEAR}"
@@ -64,10 +63,14 @@ fi
 
 # run the installation command
 echo ""
-echo "Installing Serena MCP Server..."
-if claude mcp add -s user serena -- uvx --from git+https://github.com/oraios/serena serena-mcp-server --context ide-assistant --project "$(pwd)"; then
+echo "Installing Serena MCP Server to current project..."
+if claude mcp add serena -- uvx --from git+https://github.com/oraios/serena serena-mcp-server --context ide-assistant --project "$(pwd)"; then
 	echo ""
-	echo -e "${GREEN}Serena MCP Server has been successfully installed!${CLEAR}"
+	echo -e "${GREEN}Serena MCP Server has been successfully installed to this project!${CLEAR}"
+	echo ""
+	echo -e "${YELLOW}Note:${CLEAR}"
+	echo "  - Restart Claude Code for changes to take effect"
+	echo "  - This only adds Serena MCP to the current project"
 	echo ""
 	echo -e "${YELLOW}Next step:${CLEAR}"
 	echo -e "  Run ${GREEN}/mcp__serena__initial_instructions${CLEAR} in Claude Code to get started with Serena"
@@ -77,4 +80,3 @@ else
 	echo "Please check the error messages above and try again..."
 	exit 1
 fi
-

--- a/ops/scripts/common/uninstallSerenaMcp
+++ b/ops/scripts/common/uninstallSerenaMcp
@@ -16,11 +16,12 @@ show_help() {
 	echo "  -h, --help    Display this help message"
 	echo ""
 	echo -e "${YELLOW}Description:${CLEAR}"
-	echo "  This script removes Serena MCP Server from Claude Code configuration."
+	echo "  This script removes Serena MCP Server from the current project's Claude Code configuration."
 	echo ""
 	echo -e "${YELLOW}What it does:${CLEAR}"
-	echo "  - Removes the serena block from Claude Code's .claude.json configuration"
+	echo "  - Removes Serena MCP Server from the current project only"
 	echo "  - Preserves all other MCP server configurations"
+	echo "  - Does not affect global or other project configurations"
 	echo ""
 	exit 0
 }
@@ -36,60 +37,40 @@ done
 
 echo -e "${YELLOW}Serena MCP Server Uninstaller${CLEAR}"
 
-# determine config file path
-if [ -n "$XDG_CONFIG_HOME" ]; then
-	CONFIG_FILE="$XDG_CONFIG_HOME/claude/.claude.json"
-else
-	CONFIG_FILE="$HOME/.config/claude/.claude.json"
-fi
-
-# check if config file exists
-if [ ! -f "$CONFIG_FILE" ]; then
-	echo -e "${RED}Error: Claude configuration file not found at $CONFIG_FILE${CLEAR}"
-	echo "Serena MCP Server may not be installed."
+# check if claude command is available
+if ! command -v claude &>/dev/null; then
+	echo -e "${RED}Error: 'claude' command not found.${CLEAR}"
+	echo "Please install Claude Code CLI to proceed with uninstallation..."
 	exit 1
 fi
 
-# check if jq is available
-if ! command -v jq &>/dev/null; then
-	echo -e "${RED}Error: 'jq' command not found.${CLEAR}"
-	echo "Please install jq to proceed with uninstallation..."
-	exit 1
-fi
-
-# check if serena is installed
-if ! jq -e '.mcpServers.serena' "$CONFIG_FILE" >/dev/null 2>&1; then
-	echo -e "${YELLOW}Serena MCP Server is not installed in Claude Code.${CLEAR}"
+# check if serena is installed in current project
+if ! claude mcp list | grep -q "serena"; then
+	echo -e "${YELLOW}Serena MCP Server is not installed in this project.${CLEAR}"
 	exit 0
 fi
 
 # confirm with user
-echo -e -n "Do you want to uninstall Serena MCP Server from Claude Code? [y/N] "
+echo -e -n "Do you want to uninstall Serena MCP Server from this project? [y/N] "
 read -r response
 if [[ ! "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
 	echo -e "${YELLOW}Uninstallation aborted${CLEAR}"
 	exit 0
 fi
 
-# create backup
-BACKUP_FILE="${CONFIG_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
-cp "$CONFIG_FILE" "$BACKUP_FILE"
-echo "Created backup at: $BACKUP_FILE"
-
-# remove serena from mcpServers
+# remove serena from current project
 echo ""
-echo "Removing Serena MCP Server..."
-if jq 'del(.mcpServers.serena)' "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"; then
+echo "Removing Serena MCP Server from current project..."
+if claude mcp remove serena; then
 	echo ""
-	echo -e "${GREEN}Serena MCP Server has been successfully uninstalled!${CLEAR}"
+	echo -e "${GREEN}Serena MCP Server has been successfully uninstalled from this project!${CLEAR}"
 	echo ""
 	echo -e "${YELLOW}Note:${CLEAR}"
 	echo "  - Restart Claude Code for changes to take effect"
-	echo "  - Backup saved at: $BACKUP_FILE"
+	echo "  - This only removes Serena MCP from the current project"
 else
 	echo ""
 	echo -e "${RED}Failed to uninstall Serena MCP Server.${CLEAR}"
-	echo "Restoring from backup..."
-	cp "$BACKUP_FILE" "$CONFIG_FILE"
+	echo "Please check the error messages above and try again..."
 	exit 1
 fi


### PR DESCRIPTION
- remove `-s user` flag from `claude mcp add` command
- replace `jq` config manipulation with `claude mcp` commands
- update help text to clarify project-only installation
- add consistent messaging about project scope limitations
- standardize prompts and output messages between scripts
- remove backup functionality as `claude mcp` handles this