### PR TITLE
💄style(repo): standardize everforest dark medium color scheme

### DIFF
--- a/configs/dunst/dunstrc
+++ b/configs/dunst/dunstrc
@@ -59,21 +59,21 @@ ignore_dbusclose = false
 mouse_left_click = close_current
 mouse_middle_click = do_action, close_current
 mouse_right_click = close_all
-# colors and urgency levels (everforest dark hard)
-background = "#2b3339"
+# colors and urgency levels (everforest dark medium)
+background = "#2d353b"
 foreground = "#d3c6aa"
 timeout = 3
 highlight = "#a7c080"
 # urgency_low
 [urgency_low]
-background = "#2b3339"
+background = "#2d353b"
 foreground = "#d3c6aa"
 frame_color = "#a7c080"
 timeout = 3
 highlight = "#a7c080"
 # urgency_normal
 [urgency_normal]
-background = "#2b3339"
+background = "#2d353b"
 foreground = "#d3c6aa"
 frame_color = "#83c092"
 timeout = 3

--- a/configs/glzr/glazewm/config.yaml
+++ b/configs/glzr/glazewm/config.yaml
@@ -30,7 +30,7 @@ window_effects:
   other_windows:
     border:
       enabled: true
-      color: "#475266"
+      color: "#475258"
     hide_title_bar:
       enabled: false
     corner_style:

--- a/configs/nvim/lua/plugins/ui/colorscheme/everforest_nvim.lua
+++ b/configs/nvim/lua/plugins/ui/colorscheme/everforest_nvim.lua
@@ -5,6 +5,8 @@ return {
 		lazy = false,
 		priority = 1000,
 		init = function()
+			-- set everforest background to medium
+			vim.g.everforest_background = "medium"
 			-- set neovim colorscheme
 			vim.cmd("colorscheme everforest")
 		end,

--- a/configs/nvim/lua/utils/colors.lua
+++ b/configs/nvim/lua/utils/colors.lua
@@ -2,14 +2,14 @@
 local M = {}
 -- everforest colors
 M.colors = {
-	Bg = "#2b3339",
-	Fg = "#d7d7d7",
+	Bg = "#2d353b",
+	Fg = "#d3c6aa",
 	Red = "#e67e80",
-	Green = "#a5c261",
-	Yellow = "#f9ee98",
+	Green = "#a7c080",
+	Yellow = "#dbbc7f",
 	Blue = "#7fbbb3",
-	Purple = "#c6c5fe",
-	Aqua = "#93e0e3",
-	Orange = "#f78c6c",
+	Purple = "#d699b6",
+	Aqua = "#83c092",
+	Orange = "#e69875",
 }
 return M

--- a/configs/sketchybar/colors.lua
+++ b/configs/sketchybar/colors.lua
@@ -18,8 +18,8 @@ return {
 		bg = 0xc02d353b,
 		border = 0xff7a8478,
 	},
-	bg1 = 0xff374247,
-	bg2 = 0xff374247,
+	bg1 = 0xff343f44,
+	bg2 = 0xff343f44,
 
 	with_alpha = function(color, alpha)
 		if alpha > 1.0 or alpha < 0.0 then

--- a/configs/starship/starship.toml
+++ b/configs/starship/starship.toml
@@ -3,17 +3,17 @@ format = """
 $os\
 [](bg:#a7c080 fg:#83c092)\
 $directory\
-[](fg:#a7c080 bg:#2b3339)\
+[](fg:#a7c080 bg:#2d353b)\
 $git_branch\
 $git_status\
-[](fg:#2b3339 bg:#2d353b)\
+[](fg:#2d353b bg:#343f44)\
 $nodejs\
 $rust\
 $golang\
 $php\
-[](fg:#2d353b bg:#2b3339)\
+[](fg:#343f44 bg:#2d353b)\
 $time\
-[ ](fg:#2b3339)\
+[ ](fg:#2d353b)\
 \n$character"""
 
 [os]
@@ -41,35 +41,35 @@ truncation_symbol = "…/"
 
 [git_branch]
 symbol = ""
-style = "bg:#2b3339"
-format = '[[ $symbol $branch ](fg:#a7c080 bg:#2b3339)]($style)'
+style = "bg:#2d353b"
+format = '[[ $symbol $branch ](fg:#a7c080 bg:#2d353b)]($style)'
 
 [git_status]
-style = "bg:#2b3339"
-format = '[[($all_status$ahead_behind )](fg:#a7c080 bg:#2b3339)]($style)'
+style = "bg:#2d353b"
+format = '[[($all_status$ahead_behind )](fg:#a7c080 bg:#2d353b)]($style)'
 
 [nodejs]
 symbol = ""
-style = "bg:#2d353b"
-format = '[[ $symbol ($version) ](fg:#a7c080 bg:#2d353b)]($style)'
+style = "bg:#343f44"
+format = '[[ $symbol ($version) ](fg:#a7c080 bg:#343f44)]($style)'
 
 [rust]
 symbol = ""
-style = "bg:#2d353b"
-format = '[[ $symbol ($version) ](fg:#a7c080 bg:#2d353b)]($style)'
+style = "bg:#343f44"
+format = '[[ $symbol ($version) ](fg:#a7c080 bg:#343f44)]($style)'
 
 [golang]
 symbol = ""
-style = "bg:#2d353b"
-format = '[[ $symbol ($version) ](fg:#a7c080 bg:#2d353b)]($style)'
+style = "bg:#343f44"
+format = '[[ $symbol ($version) ](fg:#a7c080 bg:#343f44)]($style)'
 
 [php]
 symbol = ""
-style = "bg:#2d353b"
-format = '[[ $symbol ($version) ](fg:#a7c080 bg:#2d353b)]($style)'
+style = "bg:#343f44"
+format = '[[ $symbol ($version) ](fg:#a7c080 bg:#343f44)]($style)'
 
 [time]
 disabled = false
 time_format = "%H:%M:%S"
-style = "bg:#2b3339"
-format = '[[   $time ](fg:#d3c6aa bg:#2b3339)]($style)'
+style = "bg:#2d353b"
+format = '[[   $time ](fg:#d3c6aa bg:#2d353b)]($style)'

--- a/configs/vim/vimrc
+++ b/configs/vim/vimrc
@@ -130,7 +130,7 @@ call plug#begin()
   Plug 'skanehira/denops-translate.vim'
 call plug#end()
 " colorscheme settings
-let g:everforest_background = 'hard'
+let g:everforest_background = 'medium'
 let g:everforest_better_performance = 1
 let g:everforest_enable_italic = 1
 let g:everforest_diagnostic_text_highlight = 1

--- a/configs/wezterm/wezterm.lua
+++ b/configs/wezterm/wezterm.lua
@@ -152,7 +152,7 @@ return {
 				fg_color = "#2d353b",
 			},
 			inactive_tab = {
-				bg_color = "#374247",
+				bg_color = "#343f44",
 				fg_color = "#83c092",
 			},
 		},


### PR DESCRIPTION
- update `dunst` notification background colors to medium variant
- modify `glazewm` window border colors for consistency
- configure `nvim` colorscheme to use medium background setting
- standardize `nvim` utility colors to match everforest palette
- adjust `sketchybar` background colors from hard to medium
- update `starship` prompt background colors throughout segments
- change `vim` colorscheme background setting to medium
- fix `wezterm` inactive tab background color alignment