### PR TITLE
🧹chore(workflow): remove push trigger from nix flake test

### DIFF
--- a/.github/workflows/test-nix-flake.yml
+++ b/.github/workflows/test-nix-flake.yml
@@ -1,8 +1,5 @@
 name: Test Nix Flake
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
- remove `push` trigger for `main` branch
- keep only `pull_request` trigger for `main` branch
- avoid duplicated testing