### PR TITLE
🧹chore(nvim): switch typescript formatter to deno_fmt

### DIFF
--- a/configs/nvim/lua/plugins/languages/lsp/servers/efm.lua
+++ b/configs/nvim/lua/plugins/languages/lsp/servers/efm.lua
@@ -83,16 +83,16 @@ function M.setup()
 				},
 				-- web
 				javascript = {
-					require("efmls-configs.formatters.prettier"),
+					require("efmls-configs.formatters.deno_fmt"),
 				},
 				typescript = {
-					require("efmls-configs.formatters.prettier"),
+					require("efmls-configs.formatters.deno_fmt"),
 				},
 				javascriptreact = {
-					require("efmls-configs.formatters.prettier"),
+					require("efmls-configs.formatters.deno_fmt"),
 				},
 				typescriptreact = {
-					require("efmls-configs.formatters.prettier"),
+					require("efmls-configs.formatters.deno_fmt"),
 				},
 				vue = {
 					require("efmls-configs.formatters.prettier"),


### PR DESCRIPTION
- replace prettier with deno_fmt for typescript files in efm lsp config