### PR TITLE
⚡deps(nix): update dependencies in `flake.lock` (2025-08-30)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     "claude-code-spec": {
       "flake": false,
       "locked": {
-        "lastModified": 1756320311,
-        "narHash": "sha256-5koS3ikDUDmUOOw4nu42qXF+Rm6+4OdCO0i1t+pma2I=",
+        "lastModified": 1756400457,
+        "narHash": "sha256-PWNrWh/6CZ3opkT+W+089P10h71BTBRFqQw3NLPMJYE=",
         "owner": "gotalab",
         "repo": "claude-code-spec",
-        "rev": "0ca251cb839a8b7d09d679ac5bd8b03fa8f2d6a3",
+        "rev": "d4bf85a634e077195d791dd4c1885f837bf47ccb",
         "type": "github"
       },
       "original": {
@@ -240,11 +240,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1756372920,
-        "narHash": "sha256-kUTDPrbBksfu/xbwyD8NAMUcu/D5jWwiCEfANgxCnG4=",
+        "lastModified": 1756467067,
+        "narHash": "sha256-egQBZALqGa6bfYtJK6mWrhxOby0Oiq23dUnIcwFT3Hg=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "4b2bfbd85f1ea77a165d9ba92d62016cdf3abfcd",
+        "rev": "05a1c0aa7395d19213e587c83089ecbd7b92085c",
         "type": "github"
       },
       "original": {
@@ -484,11 +484,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1756266583,
-        "narHash": "sha256-cr748nSmpfvnhqSXPiCfUPxRz2FJnvf/RjJGvFfaCsM=",
+        "lastModified": 1756386758,
+        "narHash": "sha256-1wxxznpW2CKvI9VdniaUnTT2Os6rdRJcRUf65ZK9OtE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8a6d5427d99ec71c64f0b93d45778c889005d9c2",
+        "rev": "dfb2f12e899db4876308eba6d93455ab7da304cd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- update `claude-code-spec` from `d4bf85a6` to `d4bf85a6`
- update `hyprland` from `05a1c0aa` to `05a1c0aa`
- update `nixpkgs` from `dfb2f12e` to `dfb2f12e`