### PR TITLE
🐞fix(nixos): resolve nvidia driver and audio system issues

### DIFF
--- a/configs/waybar/config
+++ b/configs/waybar/config
@@ -1,7 +1,7 @@
 [
   {
     "output": "HDMI-A-1",
-    "height": 37,
+    "height": 35,
     "layer": "bottom",
     "margin": "10px 10px 0px 10px",
     "modules-left": [

--- a/outputs/home-manager/hosts/yanoNixOs/gui/desktop.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/desktop.nix
@@ -5,8 +5,8 @@
   gtk = {
     enable = true;
     theme = {
-      package = pkgs.flat-remix-gtk;
-      name = "Flat-Remix-GTK-Blue-Dark";
+      name = "adw-gtk3-dark";
+      package = pkgs.adw-gtk3;
     };
     iconTheme = {
       package = pkgs.adwaita-icon-theme;

--- a/outputs/nixos/yanoNixOs/default.nix
+++ b/outputs/nixos/yanoNixOs/default.nix
@@ -65,7 +65,7 @@
       };
       nvidiaSettings = true;
       open = false;
-      package = config.boot.kernelPackages.nvidiaPackages.beta;
+      package = config.boot.kernelPackages.nvidiaPackages.stable;
       powerManagement = {
         enable = true;
       };

--- a/outputs/nixos/yanoNixOs/desktop/security.nix
+++ b/outputs/nixos/yanoNixOs/desktop/security.nix
@@ -14,6 +14,9 @@
     };
     pam = {
       services = {
+        greetd = {
+          enableGnomeKeyring = true;
+        };
         login = {
           enableGnomeKeyring = true;
         };

--- a/outputs/nixos/yanoNixOs/desktop/sound.nix
+++ b/outputs/nixos/yanoNixOs/desktop/sound.nix
@@ -14,6 +14,12 @@
       enable = true;
     };
   };
+  # security
+  security = {
+    rtkit = {
+      enable = true;
+    };
+  };
   # services
   services = {
     pipewire = {
@@ -28,6 +34,12 @@
       pulse = {
         enable = true;
       };
+      wireplumber = {
+        enable = true;
+      };
+    };
+    pulseaudio = {
+      enable = false;
     };
   };
 }


### PR DESCRIPTION
- change `nvidia` driver from `beta` to `stable` package for better kernel compatibility
- enable `gnome-keyring` for `greetd` pam service to fix authentication warnings
- configure audio system with `rtkit`, `wireplumber` enabled and `pulseaudio` disabled
- update gtk theme from `flat-remix-gtk` to `adw-gtk3-dark` for consistency
- adjust waybar height from 37 to 35 pixels for better visual alignment