### PR TITLE
🐞fix(nvim): resolve `deno_ls` and `ts_ls` conflict in monorepo

### DIFF
--- a/configs/nvim/lua/plugins/languages/lsp/servers/denols.lua
+++ b/configs/nvim/lua/plugins/languages/lsp/servers/denols.lua
@@ -1,0 +1,41 @@
+-- deno language server
+local M = {}
+
+function M.setup()
+	vim.lsp.config("denols", {
+		root_dir = function(bufnr, on_dir)
+			local buf_name = vim.fn.bufname(bufnr)
+			local buf_dir = vim.fn.fnamemodify(buf_name, ":p:h")
+			-- check if deno project
+			local current_dir = buf_dir
+			while current_dir ~= "/" do
+				if
+					vim.fn.filereadable(current_dir .. "/deno.json") == 1
+					or vim.fn.filereadable(current_dir .. "/deno.jsonc") == 1
+				then
+					on_dir(current_dir)
+					return
+				end
+				current_dir = vim.fn.fnamemodify(current_dir, ":h")
+			end
+		end,
+		settings = {
+			deno = {
+				enable = true,
+				lint = true,
+				unstable = true,
+				suggest = {
+					completeFunctionCalls = false,
+					names = true,
+					paths = true,
+					autoImports = true,
+				},
+			},
+		},
+		init_options = {
+			lint = true,
+		},
+	})
+end
+
+return M

--- a/configs/nvim/lua/plugins/languages/lsp/servers/ts_ls.lua
+++ b/configs/nvim/lua/plugins/languages/lsp/servers/ts_ls.lua
@@ -1,0 +1,61 @@
+-- typescript language server
+local M = {}
+
+function M.setup()
+	vim.lsp.config("ts_ls", {
+		root_dir = function(bufnr, on_dir)
+			local buf_name = vim.fn.bufname(bufnr)
+			local buf_dir = vim.fn.fnamemodify(buf_name, ":p:h")
+			-- check if deno project
+			local current_dir = buf_dir
+			while current_dir ~= "/" do
+				if
+					vim.fn.filereadable(current_dir .. "/deno.json") == 1
+					or vim.fn.filereadable(current_dir .. "/deno.jsonc") == 1
+				then
+					return
+				end
+				current_dir = vim.fn.fnamemodify(current_dir, ":h")
+			end
+			-- check if node project
+			current_dir = buf_dir
+			while current_dir ~= "/" do
+				if
+					vim.fn.filereadable(current_dir .. "/package.json") == 1
+					or vim.fn.filereadable(current_dir .. "/tsconfig.json") == 1
+					or vim.fn.filereadable(current_dir .. "/jsconfig.json") == 1
+				then
+					on_dir(current_dir)
+					return
+				end
+				current_dir = vim.fn.fnamemodify(current_dir, ":h")
+			end
+		end,
+		settings = {
+			typescript = {
+				inlayHints = {
+					includeInlayParameterNameHints = "all",
+					includeInlayParameterNameHintsWhenArgumentMatchesName = false,
+					includeInlayFunctionParameterTypeHints = true,
+					includeInlayVariableTypeHints = true,
+					includeInlayPropertyDeclarationTypeHints = true,
+					includeInlayFunctionLikeReturnTypeHints = true,
+					includeInlayEnumMemberValueHints = true,
+				},
+			},
+			javascript = {
+				inlayHints = {
+					includeInlayParameterNameHints = "all",
+					includeInlayParameterNameHintsWhenArgumentMatchesName = false,
+					includeInlayFunctionParameterTypeHints = true,
+					includeInlayVariableTypeHints = true,
+					includeInlayPropertyDeclarationTypeHints = true,
+					includeInlayFunctionLikeReturnTypeHints = true,
+					includeInlayEnumMemberValueHints = true,
+				},
+			},
+		},
+	})
+end
+
+return M


### PR DESCRIPTION
- add `denols.lua` server config with conditional activation for deno projects containing `deno.json` or `deno.jsonc`
- add `ts_ls.lua` server config that excludes deno projects and activates only for typescript/node.js projects
- implement mutual exclusion logic using `root_dir` function to prevent both LSP servers from running simultaneously
- support monorepo environments where deno and typescript projects coexist in separate directories