### PR TITLE
🐞fix(go): add gcc to PATH for go install compilation

### DIFF
--- a/outputs/home-manager/shared-modules/languages/go.nix
+++ b/outputs/home-manager/shared-modules/languages/go.nix
@@ -63,7 +63,8 @@ in
                 set -euo pipefail
                 export GOPATH="${config.home.homeDirectory}/go"
                 export GOBIN="$GOPATH/bin"
-                export PATH="${pkgs.go}/bin:$GOBIN:$PATH"
+                export PATH="${pkgs.gcc}/bin:${pkgs.go}/bin:$GOBIN:$PATH"
+                export CC="${pkgs.gcc}/bin/gcc"
                 for pkg in ${builtins.concatStringsSep " " goPackages}; do
                   ${pkgs.go}/bin/go install "$pkg"
                 done


### PR DESCRIPTION
- add `gcc` binary path to `PATH` environment variable
- set `CC` environment variable to point to `gcc` binary
- fix cgo compilation errors during `go install` commands