### PR TITLE
🧹chore(hypr): remove unused trackpad gesture configuration

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -59,10 +59,6 @@ input {
         scroll_factor = 0.25
     }
 }
-# gestures
-gestures {
-    workspace_swipe = true
-}
 # misc
 misc {
     disable_hyprland_logo = false


### PR DESCRIPTION
- removed `gestures` section from hyprland configuration
- configuration syntax for gestures has changed in recent hyprland versions
- trackpad gestures are not used in this setup, so removed instead of updating