### PR TITLE
🐞fix(nvim): remove missing nvim-aibo keybindings

### DIFF
--- a/configs/nvim/lua/plugins/tools/internal/which_key_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/internal/which_key_nvim.lua
@@ -16,9 +16,6 @@ return {
 				{
 					-- normal
 					mode = "n",
-					-- ai
-					{ "<LEADER>a", group = "ai" },
-					{ "<LEADER>at", "<CMD>Aibo -opener=vsplit claude<CR>", desc = "ai: toggle chat" },
 					-- buffers
 					{ "<LEADER>b", group = "buffers" },
 					{ "<LEADER>bb", "<CMD>BufferLineCyclePrev<CR>", desc = "buffer: switch to previous" },


### PR DESCRIPTION
- removed `<LEADER>a` group definition for ai
- removed `<LEADER>at` keybinding for `Aibo` command
- these removals were missed in the previous commit b584bce