### PR TITLE
🔧refactor(zsh): reorganize abbreviations and remove unused functions

### DIFF
--- a/configs/zsh/functions/ghf
+++ b/configs/zsh/functions/ghf
@@ -1,7 +1,0 @@
-function ghf() {
-  local dir=$(ghq list -p | fzf)
-
-  if [ -n "$dir" ]; then
-    eval "cd ${dir}"
-  fi
-}

--- a/configs/zsh/functions/zvm_after_init
+++ b/configs/zsh/functions/zvm_after_init
@@ -1,3 +1,0 @@
-function zvm_after_init() {
-   [ -f /usr/share/fzf/key-bindings.zsh ] && source /usr/share/fzf/key-bindings.zsh
-}

--- a/configs/zsh/rc/abbreviations.zsh
+++ b/configs/zsh/rc/abbreviations.zsh
@@ -2,11 +2,11 @@
 # abbreviations
 #
 
-# file operations
-## ccusage
-abbrev-alias ccusage="bunx ccusage"
+# alternatives
 ## cat alternative
 abbrev-alias cat="$(which bat)"
+## diff alternative
+abbrev-alias diff="$(which delta)"
 ## ls alternative
 abbrev-alias ls="$(which eza) --icons"
 ## tree alternative
@@ -28,13 +28,20 @@ abbrev-alias fm="fzf-make"
 abbrev-alias fh="fzf-make history"
 abbrev-alias fr="fzf-make repeat"
 ## git/github
+### git branch prune
 abbrev-alias gbp='git branch --merged | grep -v "\* $(git rev-parse --abbrev-ref HEAD)" | grep -v "^\s*$" | xargs -r git branch -d'
+### git hub dashboard
 abbrev-alias ghd="gh-dash"
-abbrev-alias gsf='git switch $(git branch -l | fzf | tr -d "* ")'
-abbrev-alias gitgraph="git log --graph --all --oneline --decorate"
-## editors
-abbrev-alias nvimdiff="$(which nvim) -d"
+### git branch fzf
+abbrev-alias gbf='git switch $(git branch -l | fzf | tr -d "* ")'
+### git reposirory fzf
+abbrev-alias grf='cd $(ghq list -p | fzf)'
+### git graph log
+abbrev-alias ggl="git log --graph --all --oneline --decorate"
+## lazy git
 abbrev-alias lg="lazygit"
+## editor
+abbrev-alias nvimdiff="$(which nvim) -d"
 
 # session management
 ## zellij
@@ -49,6 +56,8 @@ abbrev-alias reboot="sudo systemctl reboot"
 abbrev-alias shutdown="sudo systemctl poweroff"
 
 # applications
+## ccusage
+abbrev-alias ccusage="bunx ccusage"
 ## rtty terminal
 abbrev-alias rtty='rtty run zellij --font "PlemolJP Console NF"'
 ## trello


### PR DESCRIPTION
- remove `ghf` function and replace with `grf` alias
- remove `zvm_after_init` function for fzf key bindings
- reorganize abbreviations with better categorization
- add `diff` alias for delta
- rename git aliases for clarity (`gsf` → `gbf`, `gitgraph` → `ggl`)
- improve comments throughout abbreviations file