### PR TITLE
🔧refactor(nix): move google-chrome to system packages

### DIFF
--- a/outputs/home-manager/hosts/yanoNixOs/gui/browser.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/browser.nix
@@ -4,7 +4,6 @@
   # home
   home = {
     packages = with pkgs; [
-      google-chrome
       vivaldi
     ];
   };

--- a/outputs/nixos/shared-modules/system-packages.nix
+++ b/outputs/nixos/shared-modules/system-packages.nix
@@ -13,6 +13,7 @@
       ghq
       git
       gnumake
+      google-chrome
       killall
       libiconv
       lsof
@@ -23,5 +24,17 @@
       pkg-config
       vim
     ];
+  };
+  # systemd
+  systemd = {
+    tmpfiles = {
+      rules = [
+        # create /opt/google/chrome symlink for Chrome MCP integration
+        "d /opt 755 root root -"
+        "d /opt/google 755 root root -"
+        "d /opt/google/chrome 755 root root -"
+        "L+ /opt/google/chrome/chrome - - - - ${pkgs.google-chrome}/bin/google-chrome-stable"
+      ];
+    };
   };
 }


### PR DESCRIPTION
- move `google-chrome` from home-manager to nixos system packages
- add systemd tmpfiles rules for chrome mcp integration
- create `/opt/google/chrome` symlink for mcp compatibility