### PR TITLE
🧹chore(script): add headless and isolated options to chrome devtools mcp

### DIFF
--- a/ops/scripts/common/installChromeDevtoolsMcp
+++ b/ops/scripts/common/installChromeDevtoolsMcp
@@ -64,7 +64,7 @@ fi
 # run the installation command
 echo ""
 echo "Installing Chrome DevTools MCP Server to current project..."
-if claude mcp add chrome-devtools npx chrome-devtools-mcp@latest; then
+if claude mcp add chrome-devtools npx -- chrome-devtools-mcp@latest --headless --isolated; then
 	echo ""
 	echo -e "${GREEN}Chrome DevTools MCP Server has been successfully installed to this project!${CLEAR}"
 	echo ""


### PR DESCRIPTION
- add `--headless` option to prevent chrome ui from displaying
- add `--isolated` option to use temporary user-data-dir
- fix command syntax with `--` separator for npx arguments
- resolve neovim crashes when running chrome-devtools-mcp inside terminal