### PR TITLE
✨feat(nix): enable `direnv` with nix-direnv integration

### DIFF
--- a/configs/zsh/rc/tools.zsh
+++ b/configs/zsh/rc/tools.zsh
@@ -6,5 +6,7 @@
 if [[ "$OS" = "Darwin" ]]; then
 	eval $(/opt/homebrew/bin/brew shellenv)
 fi
+# direnv
+eval "$(direnv hook zsh)"
 # shell plugin manager
 eval "$(sheldon source)"

--- a/outputs/home-manager/shared-modules/cli/shell.nix
+++ b/outputs/home-manager/shared-modules/cli/shell.nix
@@ -40,6 +40,10 @@ in
       };
       # programs
       programs = {
+        direnv = {
+          enable = true;
+          nix-direnv.enable = true;
+        };
         zsh = {
           enable = true;
         };


### PR DESCRIPTION
- enable `direnv` in home-manager configuration
- add `nix-direnv` support for better nix shell caching
- add `direnv` hook to zsh initialization
