### PR TITLE
🧹chore(nix): remove unnecessary `libvdpau-va-gl` package

### DIFF
--- a/outputs/nixos/yanoNixOs/default.nix
+++ b/outputs/nixos/yanoNixOs/default.nix
@@ -46,14 +46,12 @@
         egl-wayland
         libGL
         libglvnd
-        libvdpau-va-gl
         mesa
         nvidia-vaapi-driver
         vaapiVdpau
       ];
       extraPackages32 = with pkgs.pkgsi686Linux; [
         libGL
-        libvdpau-va-gl
         mesa
         vaapiVdpau
       ];


### PR DESCRIPTION
- remove `libvdpau-va-gl` from `extraPackages` list
- remove `libvdpau-va-gl` from `extraPackages32` list
- this package is designed for intel GPUs to provide VDPAU
  support via VA-API wrapper
- it is redundant in nvidia GPU environment where native VDPAU
  support exists
- `nvidia-vaapi-driver` and `vaapiVdpau` already provide the
  necessary video acceleration capabilities
