### PR TITLE
✨feat(nix): add global development libraries

### DIFF
--- a/outputs/home-manager/shared-modules/cli/default.nix
+++ b/outputs/home-manager/shared-modules/cli/default.nix
@@ -3,6 +3,7 @@
   imports = [
     ./ai.nix
     ./core.nix
+    ./development.nix
     ./docker.nix
     ./editor.nix
     ./git.nix

--- a/outputs/home-manager/shared-modules/cli/development.nix
+++ b/outputs/home-manager/shared-modules/cli/development.nix
@@ -1,0 +1,14 @@
+# home development environment module
+{ pkgs, ... }:
+{
+  # home
+  home = {
+    packages = with pkgs; [
+      stdenv.cc.cc.lib
+      vips
+    ];
+    sessionVariables = {
+      LD_LIBRARY_PATH = "\${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.vips}/lib";
+    };
+  };
+}

--- a/outputs/home-manager/shared-modules/cli/shell.nix
+++ b/outputs/home-manager/shared-modules/cli/shell.nix
@@ -42,7 +42,9 @@ in
       programs = {
         direnv = {
           enable = true;
-          nix-direnv.enable = true;
+          nix-direnv = {
+            enable = true;
+          };
         };
         zsh = {
           enable = true;


### PR DESCRIPTION
- add `development.nix` module for `gcc` and `vips` libraries
- set `LD_LIBRARY_PATH` to include `stdenv.cc.cc.lib` and `vips`
- preserve existing `LD_LIBRARY_PATH` values (e.g., `pipewire-jack`)
- make development libraries available globally across all machines
- import `development.nix` in cli modules
- format `direnv.nix-direnv` configuration for consistency
