### PR TITLE
✨feat: (browser) add manual desktop entry for floorp-bin-unwrapped

### DIFF
--- a/outputs/home-manager/hosts/yanoNixOs/gui/browser.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/browser.nix
@@ -8,4 +8,48 @@
       vivaldi
     ];
   };
+  # xdg
+  xdg = {
+    desktopEntries = {
+      floorp = {
+        name = "Floorp";
+        genericName = "Web Browser";
+        exec = "floorp --name floorp %U";
+        icon = "floorp";
+        terminal = false;
+        categories = [
+          "Network"
+          "WebBrowser"
+        ];
+        mimeType = [
+          "text/html"
+          "text/xml"
+          "application/xhtml+xml"
+          "application/vnd.mozilla.xul+xml"
+          "x-scheme-handler/http"
+          "x-scheme-handler/https"
+        ];
+        startupNotify = true;
+        settings = {
+          Version = "1.5";
+          StartupWMClass = "floorp";
+          Actions = "new-private-window;new-window;profile-manager-window";
+        };
+        actions = {
+          new-private-window = {
+            name = "New Private Window";
+            exec = "floorp --private-window %U";
+          };
+          new-window = {
+            name = "New Window";
+            exec = "floorp --new-window %U";
+          };
+          profile-manager-window = {
+            name = "Profile Manager";
+            exec = "floorp --ProfileManager";
+          };
+        };
+      };
+    };
+  };
 }

--- a/outputs/nixos/yanoNixOs/desktop/xdg-mime.nix
+++ b/outputs/nixos/yanoNixOs/desktop/xdg-mime.nix
@@ -6,16 +6,16 @@
       enable = true;
       defaultApplications = {
         # web browser
-        "text/html" = [ "vivaldi.desktop" ];
-        "x-scheme-handler/http" = [ "vivaldi.desktop" ];
-        "x-scheme-handler/https" = [ "vivaldi.desktop" ];
-        "x-scheme-handler/chrome" = [ "vivaldi.desktop" ];
-        "application/x-extension-htm" = [ "vivaldi.desktop" ];
-        "application/x-extension-html" = [ "vivaldi.desktop" ];
-        "application/x-extension-shtml" = [ "vivaldi.desktop" ];
-        "application/xhtml+xml" = [ "vivaldi.desktop" ];
-        "application/x-extension-xhtml" = [ "vivaldi.desktop" ];
-        "application/x-extension-xht" = [ "vivaldi.desktop" ];
+        "text/html" = [ "vivaldi-stable.desktop" ];
+        "x-scheme-handler/http" = [ "vivaldi-stable.desktop" ];
+        "x-scheme-handler/https" = [ "vivaldi-stable.desktop" ];
+        "x-scheme-handler/chrome" = [ "vivaldi-stable.desktop" ];
+        "application/x-extension-htm" = [ "vivaldi-stable.desktop" ];
+        "application/x-extension-html" = [ "vivaldi-stable.desktop" ];
+        "application/x-extension-shtml" = [ "vivaldi-stable.desktop" ];
+        "application/xhtml+xml" = [ "vivaldi-stable.desktop" ];
+        "application/x-extension-xhtml" = [ "vivaldi-stable.desktop" ];
+        "application/x-extension-xht" = [ "vivaldi-stable.desktop" ];
         # text editor
         "text/plain" = [
           "nvim.desktop"


### PR DESCRIPTION
- add manual desktop entry for `floorp-bin-unwrapped` using home-manager
- `floorp-bin-unwrapped` does not include desktop entry by default
- include actions for new window, private window, and profile manager
- fix vivaldi desktop file reference from `vivaldi.desktop` to
`vivaldi-stable.desktop`
- ensure vivaldi remains as default browser
