### PR TITLE
🧹chore(btop): use relative theme path and enable vim keys

### DIFF
--- a/configs/btop/btop.conf
+++ b/configs/btop/btop.conf
@@ -2,7 +2,7 @@
 
 #* Name of a btop++/bpytop/bashtop formatted ".theme" file, "Default" and "TTY" for builtin themes.
 #* Themes should be placed in "../share/btop/themes" relative to binary or "$HOME/.config/btop/themes"
-color_theme = "/nix/store/wyfbzy8m0nj5ygr6ij5mbm6g9hv1s5m5-btop-1.4.4/share/btop/themes/everforest-dark-hard.theme"
+color_theme = "everforest-dark-medium"
 
 #* If the theme set background should be shown, set to False if you want terminal background transparency.
 theme_background = True
@@ -22,7 +22,7 @@ presets = "cpu:1:default,proc:0:default cpu:0:default,mem:0:default,net:0:defaul
 
 #* Set to True to enable "h,j,k,l,g,G" keys for directional control in lists.
 #* Conflicting keys for h:"help" and k:"kill" is accessible while holding shift.
-vim_keys = False
+vim_keys = True
 
 #* Rounded corners on boxes, is ignored if TTY mode is ON.
 rounded_corners = True


### PR DESCRIPTION
- change `color_theme` from absolute nix store path to relative theme name
- enable `vim_keys` for vim-style keybindings in lists
