### PR TITLE
💄style(nixos): use lowercase hyprland binary name

### DIFF
--- a/outputs/nixos/yanoNixOs/desktop/security.nix
+++ b/outputs/nixos/yanoNixOs/desktop/security.nix
@@ -35,7 +35,7 @@
       settings = {
         default_session = {
           command = ''
-            ${pkgs.tuigreet}/bin/tuigreet --time --cmd Hyprland
+            ${pkgs.tuigreet}/bin/tuigreet --time --cmd hyprland
           '';
           user = username;
         };


### PR DESCRIPTION
- change `tuigreet` startup command from `Hyprland` to
  `hyprland` for consistency with linux naming conventions
- aligns with other hypr* tools (`hyprctl`, `hyprpicker`, etc.)
  which all use lowercase names
- both binaries are functionally identical as `hyprland` is a
  symlink to `Hyprland`
