### PR TITLE
🐞fix(hyprland): freeze screen during screenshot

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -176,11 +176,11 @@ bind = SUPER, T, exec, wezterm
 bind = SUPER, L, exec, hyprlock
 ### screenshot
 #### select area and clipboard-only
-bind = SUPER SHIFT, S, exec, hyprshot -m region --clipboard-only
+bind = SUPER SHIFT, S, exec, hyprshot -z -m region --clipboard-only
 #### select window and save
-bind = SUPER SHIFT, X, exec, hyprshot -m window -o ~/google_drive/pics -f "$(date +%Y-%m-%d-%H-%M-%S).png"
+bind = SUPER SHIFT, X, exec, hyprshot -z -m window -o ~/google_drive/pics -f "$(date +%Y-%m-%d-%H-%M-%S).png"
 #### select monitor and save
-bind = SUPER SHIFT, Z, exec, hyprshot -m output -o ~/google_drive/pics -f "$(date +%Y-%m-%d-%H-%M-%S).png"
+bind = SUPER SHIFT, Z, exec, hyprshot -z -m output -o ~/google_drive/pics -f "$(date +%Y-%m-%d-%H-%M-%S).png"
 ### recording
 #### record monitor 1 (left)
 bind = SUPER SHIFT, Q, exec, wf-recorder -a -o HDMI-A-1 --audio="alsa_output.usb-Roland_Rubix24-00.analog-surround-40.monitor" --audio-volume=1.5 -f ~/google_drive/movs/rec/$(date +%Y-%m-%d-%H-%M-%S)-HDMI-A-1.mp4


### PR DESCRIPTION
- add `-z` option to `hyprshot` commands to freeze screen
- prevent animation during screenshot capture
- applies to region, window, and output screenshot modes
