### PR TITLE
🐞fix(hyprland): fix vesktop camera and screen sharing

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -91,6 +91,9 @@ env = WLR_DRM_NO_ATOMIC,1
 ## for ime
 env = QT_IM_MODULE,fcitx
 env = XMODIFIERS,@im=fcitx
+env = XDG_CURRENT_DESKTOP,Hyprland
+env = XDG_SESSION_TYPE,wayland
+env = XDG_SESSION_DESKTOP,Hyprland
 # windowrulev2
 ## vim via wezterm for ime
 windowrulev2 = float, class:FloatingVim

--- a/outputs/home-manager/hosts/yanoNixOs/gui/game.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/game.nix
@@ -4,8 +4,16 @@
   # home
   home = {
     packages = with pkgs; [
-      vesktop
       steam
+      (pkgs.vesktop.overrideAttrs (oldAttrs: {
+        postFixup = (oldAttrs.postFixup or "") + ''
+          wrapProgram $out/bin/vesktop \
+            --add-flags "--enable-features=UseOzonePlatform,WaylandWindowDecorations,WebRTCPipeWireCapturer" \
+            --add-flags "--ozone-platform=wayland" \
+            --add-flags "--disable-features=WebRtcHideLocalIpsWithMdns" \
+            --add-flags "--enable-blink-features=PipeWireCamera"
+        '';
+      }))
     ];
   };
 }

--- a/outputs/nixos/yanoNixOs/desktop/hyprland.nix
+++ b/outputs/nixos/yanoNixOs/desktop/hyprland.nix
@@ -1,5 +1,5 @@
 # nixos desktop hyprland module
-{ ... }:
+{ pkgs, ... }:
 {
   # programs
   programs = {
@@ -8,12 +8,30 @@
     };
     hyprland = {
       enable = true;
+      portalPackage = pkgs.xdg-desktop-portal-hyprland;
       xwayland = {
         enable = true;
       };
     };
     waybar = {
       enable = true;
+    };
+  };
+
+  # xdg
+  xdg = {
+    portal = {
+      config = {
+        common = {
+          default = "*";
+        };
+      };
+      enable = true;
+      extraPortals = with pkgs; [
+        xdg-desktop-portal-hyprland
+        xdg-desktop-portal-gtk
+      ];
+
     };
   };
 }


### PR DESCRIPTION
- add wayland-specific environment variables to `hyprland.conf`
- configure `xdg-desktop-portal-hyprland` in nixos module
- add wayland flags to vesktop wrapper for webcam and screenshare support
- set pipewire capturer and camera features for webrtc
