### PR TITLE
🐞fix(hyprland): fix OBS virtual camera device priority

### DIFF
--- a/outputs/home-manager/hosts/yanoNixOs/gui/media.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/media.nix
@@ -19,10 +19,4 @@
       enable = true;
     };
   };
-  # programs
-  programs = {
-    obs-studio = {
-      enable = true;
-    };
-  };
 }

--- a/outputs/nixos/yanoNixOs/desktop/camera-priority.nix
+++ b/outputs/nixos/yanoNixOs/desktop/camera-priority.nix
@@ -1,0 +1,55 @@
+# nixos desktop camera priority module
+{ pkgs, ... }:
+{
+  systemd = {
+    services = {
+      camera-priority = {
+        description = "Ensure OBS virtual camera gets video0";
+        after = [ "systemd-modules-load.service" ];
+        before = [ "systemd-udevd.service" ];
+        wantedBy = [ "sysinit.target" ];
+        unitConfig = {
+          DefaultDependencies = false;
+        };
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+        script = ''
+          # unbind all USB cameras before udev processes them
+          for usb_dev in /sys/bus/usb/devices/*/idVendor; do
+            dev_path=$(dirname "$usb_dev")
+            vendor=$(cat "$usb_dev" 2>/dev/null)
+            product=$(cat "$dev_path/idProduct" 2>/dev/null)
+            # Game Capture HD60 S+ (0fd9:006b) or Anker PowerConf C300 (291a:3361)
+            if [ "$vendor" = "0fd9" ] || [ "$vendor" = "291a" ]; then
+              dev_name=$(basename "$dev_path")
+              echo "Unbinding USB camera: $dev_name"
+              echo "$dev_name" > /sys/bus/usb/drivers/usb/unbind 2>/dev/null || true
+            fi
+          done
+          # remove v4l2loopback if loaded
+          ${pkgs.kmod}/bin/rmmod v4l2loopback 2>/dev/null || true
+          # load v4l2loopback with video_nr=0
+          ${pkgs.kmod}/bin/modprobe v4l2loopback devices=1 video_nr=0 card_label="OBS Virtual Camera" exclusive_caps=1
+          # wait a moment for the module to initialize
+          sleep 1
+          # rebind USB cameras
+          for usb_dev in /sys/bus/usb/devices/*/idVendor; do
+            dev_path=$(dirname "$usb_dev")
+            vendor=$(cat "$usb_dev" 2>/dev/null)
+            product=$(cat "$dev_path/idProduct" 2>/dev/null)
+
+            if [ "$vendor" = "0fd9" ] || [ "$vendor" = "291a" ]; then
+              dev_name=$(basename "$dev_path")
+              if [ ! -e "$dev_path/driver" ]; then
+                echo "Rebinding USB camera: $dev_name"
+                echo "$dev_name" > /sys/bus/usb/drivers/usb/bind 2>/dev/null || true
+              fi
+            fi
+          done
+        '';
+      };
+    };
+  };
+}

--- a/outputs/nixos/yanoNixOs/desktop/default.nix
+++ b/outputs/nixos/yanoNixOs/desktop/default.nix
@@ -2,12 +2,14 @@
 {
   imports = [
     ./bluetooth.nix
+    ./camera-priority.nix
     ./environment.nix
     ./fuse.nix
     ./game.nix
     ./graphics-tools.nix
     ./hwclock.nix
     ./hyprland.nix
+    ./media.nix
     ./security.nix
     ./sound.nix
     ./xdg-mime.nix

--- a/outputs/nixos/yanoNixOs/desktop/media.nix
+++ b/outputs/nixos/yanoNixOs/desktop/media.nix
@@ -1,0 +1,15 @@
+# nixos desktop media module
+{ config, ... }:
+{
+  # boot
+  boot = {
+    extraModulePackages = with config.boot.kernelPackages; [ v4l2loopback ];
+  };
+
+  # programs
+  programs = {
+    obs-studio = {
+      enable = true;
+    };
+  };
+}


### PR DESCRIPTION
- move `obs-studio` configuration from home-manager to nixos
- add `camera-priority.nix` systemd service to ensure OBS virtual
  camera gets `/dev/video0`
- unbind USB cameras before loading `v4l2loopback` module
- rebind USB cameras after `v4l2loopback` initialization
- configure `v4l2loopback` with `video_nr=0` and
  `exclusive_caps=1`
