### PR TITLE
🧹chore(lazygit): migrate config to new format

### DIFF
--- a/configs/lazygit/config.yml
+++ b/configs/lazygit/config.yml
@@ -43,10 +43,10 @@ gui:
   splitDiff: "auto" # one of 'auto' | 'always'
   skipRewordInEditorWarning: false # for skipping the confirmation before launching the reword editor
 git:
-  paging:
-    colorArg: always
-    useConfig: false
-    pager: delta --dark --paging=never --syntax-theme base16-256 -s
+  pagers:
+    - colorArg: always
+      useConfig: false
+      pager: delta --dark --paging=never --syntax-theme base16-256 -s
   commit:
     signOff: false
     verbose: default # one of 'default' | 'always' | 'never'
@@ -177,7 +177,7 @@ keybinding:
     viewResetOptions: "D"
     fetch: "f"
     toggleTreeView: "`"
-    openMergeTool: "M"
+    openMergeOptions: "M"
     openStatusFilter: "<c-b>"
   branches:
     createPullRequest: "o"


### PR DESCRIPTION
- migrate `keybinding.files.openMergeTool` to `openMergeOptions`
- migrate `git.paging` object to `git.pagers` array format
- update pager configuration structure for lazygit compatibility
