### PR TITLE
✨feat(vesktop): enable screen sharing on niri

### DIFF
--- a/configs/niri/config.kdl
+++ b/configs/niri/config.kdl
@@ -119,7 +119,7 @@ spawn-at-startup "fcitx5" "-D"
 //// clipboard history (but niri does not uses, just for saving)
 spawn-at-startup "clipse" "-listen"
 //// vesktop
-spawn-at-startup "sh" "-c" "sleep 3 && vesktop --start-minimized"
+spawn-at-startup "sh" "-c" "sleep 5 && vesktop --start-minimized"
 //// steam
 spawn-at-startup "steam" "-silent"
 // env

--- a/outputs/home-manager/hosts/yanoNixOs/gui/desktop.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/desktop.nix
@@ -1,6 +1,14 @@
 # home desktop module
 { config, pkgs, ... }:
 {
+  # dconf
+  dconf = {
+    settings = {
+      "org/gnome/desktop/interface" = {
+        color-scheme = "prefer-dark";
+      };
+    };
+  };
   # gtk
   gtk = {
     enable = true;
@@ -111,6 +119,17 @@
           env = [ ];
         };
       };
+    };
+  };
+  # xdg
+  xdg = {
+    portal = {
+      enable = true;
+      extraPortals = with pkgs; [
+        xdg-desktop-portal-gnome
+        xdg-desktop-portal-gtk
+      ];
+      xdgOpenUsePortal = true;
     };
   };
 }

--- a/outputs/home-manager/hosts/yanoNixOs/gui/game.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/game.nix
@@ -9,7 +9,9 @@
         postFixup = (oldAttrs.postFixup or "") + ''
           wrapProgram $out/bin/vesktop \
             --add-flags "--disable-features=WebRtcHideLocalIpsWithMdns" \
-            --add-flags "--enable-blink-features=PipeWireCamera"
+            --add-flags "--enable-blink-features=PipeWireCamera" \
+            --add-flags "--enable-features=UseOzonePlatform,WebRTCPipeWireCapturer" \
+            --add-flags "--ozone-platform=wayland"
         '';
       }))
     ];

--- a/outputs/nixos/yanoNixOs/desktop/niri.nix
+++ b/outputs/nixos/yanoNixOs/desktop/niri.nix
@@ -1,6 +1,12 @@
 # nixos desktop niri module
 { pkgs, ... }:
 {
+  # environment
+  environment = {
+    systemPackages = with pkgs; [
+      nautilus
+    ];
+  };
   # programs
   programs = {
     dconf = {
@@ -21,6 +27,8 @@
             "gtk"
           ];
           "org.freedesktop.impl.portal.Secret" = [ "gnome-keyring" ];
+          "org.freedesktop.impl.portal.ScreenCast" = [ "gnome" ];
+          "org.freedesktop.impl.portal.Screenshot" = [ "gnome" ];
         };
       };
       enable = true;


### PR DESCRIPTION
- add wayland native support flags to vesktop launcher
- configure xdg-desktop-portal-gnome for screencasting
- add nautilus package required for file chooser portal
- set dark theme preference via dconf settings
- increase vesktop startup delay to ensure portal readiness
- mirror system portals in home-manager to fix portal discovery
- fixes screen sharing functionality in vesktop under niri wayland
  compositor by enabling pipewire capture and proper portal
  configuration
