### PR TITLE
✨feat(nvim): add visual distinction for terminal buffers

### DIFF
--- a/configs/nvim/lua/config/autocmds.lua
+++ b/configs/nvim/lua/config/autocmds.lua
@@ -61,3 +61,14 @@ vim.api.nvim_create_autocmd("BufEnter", {
 		end
 	end,
 })
+-- show winbar for terminal buffers
+vim.api.nvim_create_autocmd("TermOpen", {
+	desc = "terminal buffer winbar",
+	pattern = "*",
+	callback = function()
+		vim.wo.winbar = "  TERMINAL"
+		vim.wo.number = false
+		vim.wo.relativenumber = false
+		vim.wo.winhighlight = "Normal:TerminalNormal,NormalNC:TerminalNormal"
+	end,
+})

--- a/configs/nvim/lua/config/claude_code.lua
+++ b/configs/nvim/lua/config/claude_code.lua
@@ -84,6 +84,8 @@ function M._recreate_split_layout()
 	-- bind existing terminal buffer
 	M._windows.terminal_win = right_win
 	vim.api.nvim_win_set_buf(right_win, M._windows.terminal_buf)
+	-- set winbar for terminal
+	vim.api.nvim_win_set_option(right_win, "winbar", "  CLAUDE CODE")
 	-- create horizontal split for prompt
 	vim.cmd("split")
 	local prompt_win = vim.api.nvim_get_current_win()
@@ -95,6 +97,8 @@ function M._recreate_split_layout()
 	vim.api.nvim_win_set_height(prompt_win, total_height - terminal_height)
 	-- bind existing prompt buffer
 	vim.api.nvim_win_set_buf(prompt_win, M._windows.prompt_buf)
+	-- set winbar for prompt
+	vim.api.nvim_win_set_option(prompt_win, "winbar", "  PROMPT")
 end
 
 -- close windows but keep buffers and process
@@ -115,7 +119,10 @@ end
 
 -- setup terminal buffer keymaps
 -- @param terminal_buf: number - terminal buffer number
-function M._setup_terminal_keymaps(terminal_buf)
+-- @param terminal_win: number - terminal window number
+function M._setup_terminal_keymaps(terminal_buf, terminal_win)
+	-- set winbar for claude code terminal
+	vim.api.nvim_win_set_option(terminal_win, "winbar", "  CLAUDE CODE")
 	-- hide layout with double Esc in normal mode
 	vim.api.nvim_buf_set_keymap(terminal_buf, "n", "<Esc><Esc>", "", {
 		callback = M.hide_layout,
@@ -142,6 +149,8 @@ function M._setup_prompt_buffer(prompt_buf, prompt_win)
 	-- set buffer options
 	vim.api.nvim_buf_set_option(prompt_buf, "buftype", "nofile")
 	vim.api.nvim_buf_set_option(prompt_buf, "filetype", "markdown")
+	-- set winbar for prompt buffer
+	vim.api.nvim_win_set_option(prompt_win, "winbar", "  PROMPT")
 	-- clear buffer content
 	vim.api.nvim_buf_set_lines(prompt_buf, 0, -1, false, {})
 	-- position cursor
@@ -194,7 +203,7 @@ function M._start_claude_terminal(terminal_buf, terminal_win, command)
 	end
 
 	M._windows.claude_job_id = job_id
-	M._setup_terminal_keymaps(terminal_buf)
+	M._setup_terminal_keymaps(terminal_buf, terminal_win)
 	return true
 end
 

--- a/configs/nvim/lua/plugins/tools/internal/toggleterm_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/internal/toggleterm_nvim.lua
@@ -50,6 +50,10 @@ return {
 						return vim.o.columns * 0.5
 					end
 				end,
+				highlights = {
+					Normal = { link = "TerminalNormal" },
+					NormalNC = { link = "TerminalNormal" },
+				},
 			})
 			-- keymaps
 			-- to avoid not opening terminal after opened and exited, set keymaps here again

--- a/configs/nvim/lua/plugins/ui/colorscheme/everforest_nvim.lua
+++ b/configs/nvim/lua/plugins/ui/colorscheme/everforest_nvim.lua
@@ -4,10 +4,14 @@ return {
 		"neanias/everforest-nvim",
 		lazy = false,
 		priority = 1000,
-		init = function()
-			-- set everforest background to medium
-			vim.g.everforest_background = "medium"
-			-- set neovim colorscheme
+		config = function()
+			require("everforest").setup({
+				background = "medium",
+				on_highlights = function(hl, palette)
+					hl.TerminalNormal = { bg = palette.bg_dim }
+					hl.TerminalNormalNC = { bg = palette.bg_dim }
+				end,
+			})
 			vim.cmd("colorscheme everforest")
 		end,
 	},


### PR DESCRIPTION
- add `TerminalNormal` highlight with darker background in everforest
- configure toggleterm to use `TerminalNormal` highlight
- add winbar showing "TERMINAL" label for terminal buffers
- add winbar showing "CLAUDE CODE" for claude code terminal
- add winbar showing "PROMPT" for claude code prompt buffer
- disable line numbers in terminal windows
- apply custom highlight via `winhighlight` option in autocmd
