### PR TITLE
✨feat(ai): add comfyui, invokeai, fooocus integration

### DIFF
--- a/configs/comfyui/extra_model_paths.yaml
+++ b/configs/comfyui/extra_model_paths.yaml
@@ -1,0 +1,8 @@
+comfyui:
+  base_path: /home/yanosea/google_drive/ai/
+  checkpoints: models/
+  loras: loras/
+  embeddings: embeddings/
+  vae: vae/
+  controlnet: controlnet/
+  upscale_models: upscalers/

--- a/configs/fooocus/config.txt
+++ b/configs/fooocus/config.txt
@@ -1,0 +1,39 @@
+{
+  "path_checkpoints": [
+    "/home/yanosea/google_drive/ai/models"
+  ],
+  "path_loras": [
+    "/home/yanosea/google_drive/ai/loras"
+  ],
+  "path_embeddings": [
+    "/home/yanosea/google_drive/ai/embeddings"
+  ],
+  "path_vae": [
+    "/home/yanosea/google_drive/ai/vae"
+  ],
+  "path_upscale_models": [
+    "/home/yanosea/google_drive/ai/upscalers"
+  ],
+  "path_inpaint": [
+    "/home/yanosea/google_drive/ai/inpaint"
+  ],
+  "path_controlnet": [
+    "/home/yanosea/google_drive/ai/controlnet"
+  ],
+  "path_outputs": "/home/yanosea/google_drive/ai/outputs/fooocus",
+  "default_model": "juggernautXL_v8Rundiffusion.safetensors",
+  "default_refiner": "",
+  "default_loras": [],
+  "default_cfg_scale": 7.0,
+  "default_sample_sharpness": 2.0,
+  "default_sampler": "dpmpp_2m_sde_gpu",
+  "default_scheduler": "karras",
+  "default_styles": [
+    "Fooocus V2",
+    "Fooocus Enhance",
+    "Fooocus Sharp"
+  ],
+  "default_prompt_negative": "(worst quality, low quality:1.4), watermark, signature, ugly, poorly drawn",
+  "default_aspect_ratio": "1152×896",
+  "default_performance": "Speed"
+}

--- a/configs/invokeai/invokeai.yaml
+++ b/configs/invokeai/invokeai.yaml
@@ -1,0 +1,54 @@
+schema_version: 4.0.2
+host: 127.0.0.1
+port: 9090
+allow_origins: []
+allow_credentials: true
+allow_methods:
+  - "*"
+allow_headers:
+  - "*"
+log_tokenization: false
+patchmatch: true
+models_dir: /home/yanosea/google_drive/ai/models
+convert_cache_dir: models/.convert_cache
+download_cache_dir: models/.download_cache
+legacy_conf_dir: configs
+db_dir: databases
+outputs_dir: /home/yanosea/google_drive/ai/outputs/invokeai
+custom_nodes_dir: nodes
+style_presets_dir: style_presets
+workflow_thumbnails_dir: workflow_thumbnails
+log_handlers:
+  - console
+log_format: color
+log_level: info
+log_sql: false
+log_level_network: warning
+use_memory_db: false
+dev_reload: false
+profile_graphs: false
+profiles_dir: profiles
+log_memory_usage: false
+device_working_mem_gb: 3.0
+enable_partial_loading: false
+keep_ram_copy_of_weights: true
+lazy_offload: true
+device: auto
+precision: auto
+sequential_guidance: false
+attention_type: auto
+attention_slice_size: auto
+force_tiled_decode: false
+pil_compress_level: 1
+max_queue_size: 10000
+clear_queue_on_startup: false
+node_cache_size: 512
+hashing_algorithm: blake3_single
+remote_api_tokens:
+  - url_regex: cool-models.com
+    token: my_secret_token
+  - url_regex: nifty-models.com
+    token: some_other_token
+scan_models_on_startup: true
+unsafe_disable_picklescan: false
+allow_unknown_models: true

--- a/flake.lock
+++ b/flake.lock
@@ -60,6 +60,48 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
+          "nixified-ai",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixified-ai",
+          "hercules-ci-effects",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-parts",
+        "type": "indirect"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
           "wrangler",
           "nixpkgs"
         ]
@@ -75,6 +117,45 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "hercules-ci-effects": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixified-ai",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733333617,
+        "narHash": "sha256-nMMQXREGvLOLvUa0ByhYFdaL0Jov0t1wzLbKjr05P2w=",
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
+        "rev": "56f8ea8d502c87cf62444bec4ee04512e8ea24ea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "hercules-ci-effects",
         "type": "github"
       }
     },
@@ -118,6 +199,70 @@
         "type": "github"
       }
     },
+    "nix-comfyui": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "poetry2nix": "poetry2nix"
+      },
+      "locked": {
+        "lastModified": 1733961600,
+        "narHash": "sha256-kEM0Dck4K4dg9QYmdldy62av+XzsNz9XhfTAhtGWwzo=",
+        "owner": "dyscorv",
+        "repo": "nix-comfyui",
+        "rev": "cbd17e10b53dcf8fd9f5ba6f3c1ea1a550082659",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dyscorv",
+        "repo": "nix-comfyui",
+        "type": "github"
+      }
+    },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-comfyui",
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729742964,
+        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nixified-ai": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "hercules-ci-effects": "hercules-ci-effects",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1761469061,
+        "narHash": "sha256-JeYQuRLnMJkO+i1J2Zx80r+zjA1C59vJvuRlBUjAIqM=",
+        "owner": "nixified-ai",
+        "repo": "flake",
+        "rev": "b35ad969edb807534c22e428044b30762aa0dc08",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixified-ai",
+        "repo": "flake",
+        "type": "github"
+      }
+    },
     "nixos-hardware": {
       "locked": {
         "lastModified": 1762847253,
@@ -157,6 +302,20 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1733749988,
+        "narHash": "sha256-+5qdtgXceqhK5ZR1YbP1fAUsweBIrhL38726oIEAtDs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bc27f0fde01ce4e1bfec1ab122d72b7380278e68",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1762844143,
         "narHash": "sha256-SlybxLZ1/e4T2lb1czEtWVzDCVSTvk9WLwGhmxFmBxI=",
         "owner": "nixos",
@@ -171,17 +330,50 @@
         "type": "github"
       }
     },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": [
+          "nix-comfyui",
+          "flake-utils"
+        ],
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "nix-comfyui",
+          "nixpkgs"
+        ],
+        "systems": [
+          "nix-comfyui",
+          "flake-utils",
+          "systems"
+        ],
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1731205797,
+        "narHash": "sha256-F7N1mxH1VrkVNHR3JGNMRvp9+98KYO4b832KS8Gl2xI=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "f554d27c1544d9c56e5f1f8e2b8aff399803674e",
+        "type": "github"
+      },
+      "original": {
+        "id": "poetry2nix",
+        "type": "indirect"
+      }
+    },
     "root": {
       "inputs": {
         "darwin": "darwin",
         "fenix": "fenix",
         "home-manager": "home-manager",
         "mediaplayer": "mediaplayer",
+        "nix-comfyui": "nix-comfyui",
+        "nixified-ai": "nixified-ai",
         "nixos-hardware": "nixos-hardware",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "sops-nix": "sops-nix",
-        "treefmt-nix": "treefmt-nix",
+        "treefmt-nix": "treefmt-nix_2",
         "wrangler": "wrangler"
       }
     },
@@ -222,7 +414,44 @@
         "type": "github"
       }
     },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-comfyui",
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1730120726,
+        "narHash": "sha256-LqHYIxMrl/1p3/kvm2ir925tZ8DkI0KA10djk8wecSk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "9ef337e492a5555d8e17a51c911ff1f02635be15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
@@ -244,7 +473,7 @@
     },
     "wrangler": {
       "inputs": {
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,17 @@
     };
     # packages
     ## mediaplayer
+    nix-comfyui = {
+      url = "github:dyscorv/nix-comfyui";
+    };
+    nixified-ai = {
+      url = "github:nixified-ai/flake";
+      inputs = {
+        nixpkgs = {
+          follows = "nixpkgs";
+        };
+      };
+    };
     mediaplayer = {
       url = "github:nomisreual/mediaplayer";
       inputs = {

--- a/outputs/home-manager/hosts/yanoNixOs/gui/ai.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/ai.nix
@@ -1,0 +1,150 @@
+# home ai module
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  # home
+  home = {
+    packages = with pkgs; [
+      cuda-comfyui
+      invokeai
+      fooocus
+    ];
+    file = {
+      ".local/bin/start-comfyui" = {
+        executable = true;
+        text = ''
+          #!/usr/bin/env bash
+          set -e
+          # Setup config
+          mkdir -p ${config.home.homeDirectory}/.local/share/comfyui
+          ln -sf ${config.xdg.configHome}/comfyui/extra_model_paths.yaml ${config.home.homeDirectory}/.local/share/comfyui/extra_model_paths.yaml
+          cd ${config.home.homeDirectory}/.local/share/comfyui
+          # Set environment
+          export CUDA_VISIBLE_DEVICES=0
+          export NIX_COMFYUI_STATE_DIRS=custom_nodes
+          export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+          echo "Starting ComfyUI on http://127.0.0.1:8188"
+          echo "Press Ctrl+C to stop"
+          # Start ComfyUI
+          exec ${lib.getExe' pkgs.cuda-comfyui "comfyui"} --listen 127.0.0.1 --port 8188 --output-directory ${config.home.homeDirectory}/google_drive/ai/outputs/comfyui
+        '';
+      };
+      ".local/bin/start-fooocus" = {
+        executable = true;
+        text = ''
+          #!/usr/bin/env bash
+          set -e
+          # Setup config
+          ln -sf ${config.xdg.configHome}/fooocus/config.txt ${config.home.homeDirectory}/.local/share/Fooocus/config.txt
+          # Set environment
+          export CUDA_VISIBLE_DEVICES=0
+          export FOOOCUS_ROOT=${config.home.homeDirectory}/.local/share/Fooocus
+          export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+          echo "Starting Fooocus on http://127.0.0.1:7865"
+          echo "Press Ctrl+C to stop"
+          # Run inside FHS environment
+          exec ${pkgs.fooocus}/bin/fooocus ${pkgs.writeShellScript "fooocus-inner" ''
+            set -e
+            cd ${config.home.homeDirectory}/.local/share
+            # Initial setup if needed
+            if [ ! -f "Fooocus/.fooocus-installed" ]; then
+              if [ ! -d "Fooocus" ]; then
+                echo "Cloning Fooocus repository..."
+                git clone https://github.com/lllyasviel/Fooocus.git
+              fi
+              cd ${config.home.homeDirectory}/.local/share/Fooocus
+              echo "Creating virtual environment..."
+              python3.11 -m venv venv
+              source venv/bin/activate
+              echo "Installing dependencies..."
+              pip install --upgrade pip
+              pip install -r requirements_versions.txt
+              if [ $? -eq 0 ]; then
+                touch ${config.home.homeDirectory}/.local/share/Fooocus/.fooocus-installed
+              else
+                echo "Installation failed!"
+                exit 1
+              fi
+            fi
+            # Start  Fooocus
+            if [ -f "Fooocus/.fooocus-installed" ] && [ -d "Fooocus/venv" ]; then
+              cd ${config.home.homeDirectory}/.local/share/Fooocus
+              source venv/bin/activate
+              exec python launch.py --listen 127.0.0.1 --port 7865
+            else
+              echo "Fooocus not properly installed!"
+              exit 1
+            fi
+          ''}
+        '';
+      };
+      ".local/bin/start-invokeai" = {
+        executable = true;
+        text = ''
+          #!/usr/bin/env bash
+          set -e
+          # Setup config
+          rm -f ${config.home.homeDirectory}/.local/share/invokeai/invokeai.yaml
+          cp ${config.xdg.configHome}/invokeai/invokeai.yaml ${config.home.homeDirectory}/.local/share/invokeai/invokeai.yaml
+          # Set environment
+          export CUDA_VISIBLE_DEVICES=0
+          export INVOKEAI_ROOT=${config.home.homeDirectory}/.local/share/invokeai
+          export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+          echo "Starting InvokeAI on http://127.0.0.1:9090"
+          echo "Press Ctrl+C to stop"
+          # Run inside FHS environment
+          exec ${pkgs.invokeai}/bin/invokeai ${pkgs.writeShellScript "invokeai-inner" ''
+            set -e
+            cd ${config.home.homeDirectory}/.local/share/invokeai
+            # Initial setup if needed
+            if [ ! -f ".invokeai-installed" ]; then
+              echo "Setting up InvokeAI for the first time..."
+              python3.11 -m venv venv
+              source venv/bin/activate
+              pip install --upgrade pip
+              pip install "InvokeAI[xformers]" --upgrade
+              if [ $? -eq 0 ]; then
+                touch ${config.home.homeDirectory}/.local/share/invokeai/.invokeai-installed
+              else
+                echo "Installation failed!"
+                exit 1
+              fi
+            fi
+            # Start InvokeAI
+            if [ -f ".invokeai-installed" ] && [ -d "venv" ]; then
+              source venv/bin/activate
+              exec invokeai-web --root ${config.home.homeDirectory}/.local/share/invokeai
+            else
+              echo "InvokeAI not properly installed!"
+              exit 1
+            fi
+          ''}
+        '';
+      };
+    };
+  };
+  # systemd
+  systemd = {
+    user = {
+      tmpfiles = {
+        rules = [
+          "d ${config.home.homeDirectory}/google_drive/ai 0755 - - -"
+          "d ${config.home.homeDirectory}/google_drive/ai/models 0755 - - -"
+          "d ${config.home.homeDirectory}/google_drive/ai/loras 0755 - - -"
+          "d ${config.home.homeDirectory}/google_drive/ai/embeddings 0755 - - -"
+          "d ${config.home.homeDirectory}/google_drive/ai/vae 0755 - - -"
+          "d ${config.home.homeDirectory}/google_drive/ai/controlnet 0755 - - -"
+          "d ${config.home.homeDirectory}/google_drive/ai/upscalers 0755 - - -"
+          "d ${config.home.homeDirectory}/google_drive/ai/outputs 0755 - - -"
+          "d ${config.home.homeDirectory}/.local/share/comfyui 0755 - - -"
+          "d ${config.home.homeDirectory}/.local/share/comfyui/custom_nodes 0755 - - -"
+          "d ${config.home.homeDirectory}/.local/share/invokeai 0755 - - -"
+        ];
+      };
+    };
+  };
+}

--- a/outputs/home-manager/hosts/yanoNixOs/gui/default.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/default.nix
@@ -1,6 +1,7 @@
 # yanoNixOs specific gui modules for home
 {
   imports = [
+    ./ai.nix
     ./browser.nix
     ./daw.nix
     ./desktop.nix

--- a/outputs/nixos/shared-modules/nix.nix
+++ b/outputs/nixos/shared-modules/nix.nix
@@ -20,11 +20,13 @@
         "https://cache.nixos.org"
         "https://nix-community.cachix.org"
         "https://wrangler.cachix.org"
+        "https://ai.cachix.org"
       ];
       trusted-public-keys = [
         "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
         "wrangler.cachix.org-1:N/FIcG2qBQcolSpklb2IMDbsfjZKWg+ctxx0mSMXdSs="
+        "ai.cachix.org-1:N9dzRK+alWwoKXQlnn0H6aUx0lU/mspIoz8hMvGvbbc="
       ];
       trusted-users = [
         "root"

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -17,4 +17,115 @@ inputs: [
   (final: prev: {
     wrangler = inputs.wrangler.packages.${prev.stdenv.hostPlatform.system}.default;
   })
+  ## invokeai
+  (
+    final: prev:
+    let
+      buildFHSUserEnv = prev.buildFHSUserEnv or prev.buildFHSEnv;
+    in
+    {
+      invokeai = buildFHSUserEnv {
+        name = "invokeai";
+        targetPkgs =
+          pkgs:
+          (with pkgs; [
+            alsa-lib
+            glib
+            gtk3
+            libGL
+            libGLU
+            python311
+            python311Packages.pip
+            python311Packages.virtualenv
+            stdenv.cc.cc.lib
+            xorg.libX11
+            xorg.libXext
+            xorg.libXrender
+            zlib
+          ]);
+        profile = ''
+          export INVOKEAI_ROOT=~/.local/share/invokeai
+        '';
+        runScript = "${prev.bash}/bin/bash";
+        meta = with prev.lib; {
+          description = "InvokeAI";
+          homepage = "https://invoke-ai.github.io/InvokeAI";
+          license = licenses.mit;
+          platforms = platforms.linux;
+        };
+      };
+    }
+  )
+  ## fooocus
+  (
+    final: prev:
+    let
+      buildFHSUserEnv = prev.buildFHSUserEnv or prev.buildFHSEnv;
+      openblas-pc = prev.writeTextFile {
+        name = "openblas-pc";
+        destination = "/lib/pkgconfig/openblas.pc";
+        text = ''
+          libdir=${prev.openblas}/lib
+          includedir=${prev.openblas}/include
+          Name: OpenBLAS
+          Description: OpenBLAS is an optimized BLAS library
+          Version: ${prev.openblas.version}
+          Libs: -L''${libdir} -lopenblas
+          Cflags: -I''${includedir}
+        '';
+      };
+    in
+    {
+      fooocus = buildFHSUserEnv {
+        name = "fooocus";
+        targetPkgs =
+          pkgs:
+          (with pkgs; [
+            alsa-lib
+            cmake
+            cudaPackages.cudatoolkit
+            cudaPackages.cudnn
+            gcc
+            gfortran
+            git
+            git-lfs
+            glib
+            gnumake
+            gtk3
+            libGL
+            libGLU
+            linuxPackages.nvidia_x11
+            openblas
+            openblas-pc
+            pkg-config
+            python311
+            python311Packages.pip
+            python311Packages.virtualenv
+            stdenv.cc.cc.lib
+            xorg.libX11
+            xorg.libXext
+            xorg.libXrender
+            zlib
+          ]);
+        multiPkgs = pkgs: (with pkgs; [ openblas ]);
+        profile = ''
+          export FOOOCUS_ROOT=~/.local/share/Fooocus
+          export PKG_CONFIG_PATH="${openblas-pc}/lib/pkgconfig:$PKG_CONFIG_PATH"
+          export LDFLAGS="-L${prev.openblas}/lib $LDFLAGS"
+          export CPPFLAGS="-I${prev.openblas}/include $CPPFLAGS"
+        '';
+        runScript = "${prev.bash}/bin/bash";
+        meta = with prev.lib; {
+          description = "Fooocus";
+          homepage = "https://github.com/lllyasviel/Fooocus";
+          license = licenses.gpl3;
+          platforms = platforms.linux;
+        };
+      };
+    }
+  )
+  ## cuda-comfyui
+  (final: prev: {
+    cuda-comfyui = inputs.nix-comfyui.packages.${prev.stdenv.hostPlatform.system}.cuda-comfyui;
+  })
 ]


### PR DESCRIPTION
- add `nix-comfyui` and `nixified-ai` flake inputs
- create `outputs/home-manager/hosts/yanoNixOs/gui/ai.nix` module for ai
tools configuration
- add configuration files for `ComfyUI`, `InvokeAI`, and `Fooocus` with
shared model paths
- implement custom `FHS` environments for `InvokeAI` and `Fooocus` in
overlays
- create startup wrapper scripts (`start-comfyui`, `start-fooocus`,
`start-invokeai`) in `~/.local/bin`
- configure shared model directory structure in `~/google_drive/ai/`
- add `ai.cachix.org` binary cache for faster builds
- set up `systemd` tmpfiles rules for required directories
- integrate `cuda-comfyui` package from `nix-comfyui` flake
