### PR TITLE
🚀perf(nixos): optimize system shutdown speed

### DIFF
--- a/outputs/home-manager/hosts/yanoNixOs/gui/media.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/media.nix
@@ -19,4 +19,16 @@
       enable = true;
     };
   };
+  # systemd
+  systemd = {
+    user = {
+      services = {
+        easyeffects = {
+          Service = {
+            TimeoutStopSec = 5;
+          };
+        };
+      };
+    };
+  };
 }

--- a/outputs/nixos/yanoNixOs/default.nix
+++ b/outputs/nixos/yanoNixOs/default.nix
@@ -23,10 +23,12 @@
     initrd = {
       kernelModules = [
         "fuse"
-        "nvidia"
       ];
     };
     kernelPackages = pkgs.linuxPackages_latest;
+    kernelParams = [
+      "usbcore.autosuspend=-1"
+    ];
     loader = {
       systemd-boot = {
         enable = true;


### PR DESCRIPTION
- reduce `easyeffects` shutdown timeout from 90s to 5s
- remove `nvidia` module from initrd to improve boot time
- disable USB autosuspend to prevent shutdown delays
- fix slow shutdown caused by easyeffects and Quest 2 USB errors
