### PR TITLE
🐞fix(ai): add build dependencies for patchmatch

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -30,10 +30,14 @@ inputs: [
           pkgs:
           (with pkgs; [
             alsa-lib
+            gcc
             glib
+            gnumake
             gtk3
             libGL
             libGLU
+            opencv4
+            pkg-config
             python311
             python311Packages.pip
             python311Packages.virtualenv


### PR DESCRIPTION
- add `gcc` compiler for C++ compilation
- add `gnumake` for running Makefile
- add `opencv4` development library for image processing
- add `pkg-config` for finding OpenCV during compilation
- resolve patchmatch compilation error in FHS environment
