### PR TITLE
🧹chore(systemd): configure user service timeout

### DIFF
--- a/outputs/nixos/yanoNixOs/default.nix
+++ b/outputs/nixos/yanoNixOs/default.nix
@@ -77,6 +77,14 @@
       enable = true;
     };
   };
+  # systemd
+  systemd = {
+    user = {
+      extraConfig = ''
+        DefaultTimeoutStopSec=5s
+      '';
+    };
+  };
   # users
   users = {
     users = {


### PR DESCRIPTION
- add `DefaultTimeoutStopSec=5s` to systemd user configuration
- reduce default stop timeout from 90s to 5s for faster service shutdown
