### PR TITLE
🐞fix(niri): fix screenshot keybindings syntax

### DIFF
--- a/configs/niri/config.kdl
+++ b/configs/niri/config.kdl
@@ -279,8 +279,9 @@ binds {
     }
     // shortcuts
     //// screenshots (clipboard only)
+    ////// regional screenshot must change save or not in the ui
     Super+S {
-        screenshot write-to-disk=false
+        screenshot
     }
     Super+X {
         screenshot-window write-to-disk=false
@@ -290,13 +291,13 @@ binds {
     }
     //// screenshots (clipboard + save to disk)
     Super+Shift+S {
-        screenshot write-to-disk=true
+        screenshot
     }
     Super+Shift+X {
-        screenshot-window write-to-disk=true
+        screenshot-window
     }
     Super+Shift+Z {
-        screenshot-screen write-to-disk=true
+        screenshot-screen
     }
     //// Screen Recording
     Super+Shift+Q {


### PR DESCRIPTION
- remove invalid `write-to-disk` parameter from `screenshot` action
- use `write-to-disk=false` only for `screenshot-window` and
  `screenshot-screen`
- remove redundant `write-to-disk=true` (default behavior)
- add comment explaining `Super+S` requires manual UI interaction
