### PR TITLE
🐞fix(media): resolve easyeffects startup timeout and dbus registration issues

### DIFF
--- a/outputs/home-manager/hosts/yanoNixOs/gui/media.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/media.nix
@@ -1,5 +1,10 @@
 # home media module
-{ lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 {
   # home
   home = {
@@ -25,7 +30,13 @@
       services = {
         easyeffects = {
           Service = {
+            ExecStart = lib.mkForce "${pkgs.easyeffects}/bin/easyeffects --service-mode";
+            TimeoutStartSec = lib.mkForce 30;
             TimeoutStopSec = lib.mkForce 5;
+            Type = lib.mkForce "simple";
+          };
+          Unit = {
+            After = lib.mkForce [ "pipewire.service" ];
           };
         };
       };


### PR DESCRIPTION
- change deprecated `--gapplication-service` flag to `--service-mode`
- change service type from `dbus` to `simple` to avoid dbus name registration hang
- add `After=pipewire.service` to ensure pipewire starts before easyeffects
- set `TimeoutStartSec` to 30 seconds for simple service type
- add `config` parameter to module arguments for future tmpfiles configuration
