### PR TITLE
✨feat(dock) add vesktop to dock apps

### DIFF
--- a/outputs/darwin/shared-modules/defaults/dock.nix
+++ b/outputs/darwin/shared-modules/defaults/dock.nix
@@ -26,6 +26,9 @@
             app = "/Applications/Vivaldi.app";
           }
           {
+            app = "/Applications/Vesktop.app";
+          }
+          {
             app = "/Applications/WezTerm.app";
           }
           {


### PR DESCRIPTION
- add `Vesktop.app` to the list of dock applications in
  `outputs/darwin/shared-modules/defaults/dock.nix`
