### PR TITLE
⚡deps(nix): update dependencies in `flake.lock` (2025-11-27)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763505477,
-        "narHash": "sha256-nJRd4LY2kT3OELfHqdgWjvToNZ4w+zKCMzS2R6z4sXE=",
+        "lastModified": 1764161084,
+        "narHash": "sha256-HN84sByg9FhJnojkGGDSrcjcbeioFWoNXfuyYfJ1kBE=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "3bda9f6b14161becbd07b3c56411f1670e19b9b5",
+        "rev": "e95de00a471d07435e0527ff4db092c84998698e",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1764075860,
-        "narHash": "sha256-KYEIHCBBw+/lwKsJNRNoUxBB4ZY2LK0G0T8f+0i65q0=",
+        "lastModified": 1764135300,
+        "narHash": "sha256-5xOuutXM7UPTUcn3uDAD8UlPQsXmqPrX81cXoDOAGcA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "295d90e22d557ccc3049dc92460b82f372cd3892",
+        "rev": "f4cb25928fafa9ae68660fe71f730fc820a59028",
         "type": "github"
       },
       "original": {
@@ -250,11 +250,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763708689,
-        "narHash": "sha256-bynP/qit1ToDOcDTX+XYTPpm8UNQBeYwmu22G8mgrbs=",
+        "lastModified": 1764111191,
+        "narHash": "sha256-YniflKXC20MIVGAWqC1/r58Ujq4/5mWwrP0IDdM0nzY=",
         "owner": "emrldnix",
         "repo": "wrangler",
-        "rev": "847bdd2f487ddfa111a6704957cbebd84cb8f9ca",
+        "rev": "17be3f8cd577cb410dba14dbf7a1c18ba1f110a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- update `darwin` from `3bda9f6b` to `e95de00a`
- update `home-manager` from `295d90e2` to `f4cb2592`
- update `wrangler` from `847bdd2f` to `17be3f8c`