### PR TITLE
🐞fix(easyeffects): use --gapplication-service flag

### DIFF
--- a/outputs/home-manager/hosts/yanoNixOs/gui/media.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/media.nix
@@ -30,7 +30,7 @@
       services = {
         easyeffects = {
           Service = {
-            ExecStart = lib.mkForce "${pkgs.easyeffects}/bin/easyeffects --service-mode";
+            ExecStart = lib.mkForce "${pkgs.easyeffects}/bin/easyeffects --gapplication-service";
             TimeoutStartSec = lib.mkForce 30;
             TimeoutStopSec = lib.mkForce 5;
             Type = lib.mkForce "simple";


### PR DESCRIPTION
- change `--service-mode` to `--gapplication-service` flag
- prevent window from displaying on startup
- run `easyeffects` as background service properly
