### PR TITLE
🐞fix(nvim): add fallback palette for first startup

### DIFF
--- a/configs/nvim/lua/plugins/ui/components/todo_comments_nvim.lua
+++ b/configs/nvim/lua/plugins/ui/components/todo_comments_nvim.lua
@@ -45,12 +45,12 @@ return {
 				exclude = {},
 			},
 			colors = {
-				error = { "DiagnosticError", "ErrorMsg", require("utils.colors").colors.red },
-				warning = { "DiagnosticWarn", "WarningMsg", require("utils.colors").colors.yellow },
-				info = { "DiagnosticInfo", require("utils.colors").colors.blue },
-				hint = { "DiagnosticHint", require("utils.colors").colors.green },
-				default = { "Identifier", require("utils.colors").colors.purple },
-				test = { "Identifier", require("utils.colors").colors.orange },
+				error = { "DiagnosticError", "ErrorMsg", require("utils.colors").colors.Red },
+				warning = { "DiagnosticWarn", "WarningMsg", require("utils.colors").colors.Yellow },
+				info = { "DiagnosticInfo", require("utils.colors").colors.Blue },
+				hint = { "DiagnosticHint", require("utils.colors").colors.Green },
+				default = { "Identifier", require("utils.colors").colors.Purple },
+				test = { "Identifier", require("utils.colors").colors.Orange },
 			},
 			search = {
 				command = "rg",

--- a/configs/nvim/lua/utils/colors.lua
+++ b/configs/nvim/lua/utils/colors.lua
@@ -1,20 +1,55 @@
--- define colors using everforest palette
+-- define colors using everforest palette with fallback support
 local M = {}
 
+-- fallback palette for everforest medium/dark theme
+-- used when everforest plugin is not yet installed (first-time startup)
+local fallback_palette = {
+	bg0 = "#2d353b",
+	fg = "#d3c6aa",
+	red = "#e67e80",
+	green = "#a7c080",
+	yellow = "#dbbc7f",
+	blue = "#7fbbb3",
+	purple = "#d699b6",
+	aqua = "#83c092",
+	orange = "#e69875",
+}
+
 local function get_palette()
-	local _, everforest = pcall(require, "everforest")
+	-- safely check if everforest is available
+	local ok, everforest = pcall(require, "everforest")
+	if not ok or type(everforest) ~= "table" then
+		return fallback_palette
+	end
+
+	-- safely check if everforest.colours is available
+	local colours_ok, colours = pcall(require, "everforest.colours")
+	if not colours_ok or type(colours) ~= "table" or type(colours.generate_palette) ~= "function" then
+		return fallback_palette
+	end
+
+	-- get config with defaults
 	local config = everforest.config or {}
 	local background = config.background or "medium"
-	local colours = require("everforest.colours")
 	local theme = vim.o.background or "dark"
 	local options = {
 		background = background,
 		colours_override = function() end,
 	}
-	return colours.generate_palette(options, theme)
+
+	-- safely generate palette
+	local palette_ok, palette = pcall(colours.generate_palette, options, theme)
+	if not palette_ok or type(palette) ~= "table" then
+		return fallback_palette
+	end
+
+	return palette
 end
+
 -- generate colors from palette
 local palette = get_palette()
+
+-- export colors with PascalCase keys
 M.colors = {
 	Bg = palette.bg0,
 	Fg = palette.fg,


### PR DESCRIPTION
- add hardcoded fallback palette with everforest medium/dark colors
- fix `pcall` error handling to properly check success status
- protect all `require` calls with `pcall` to prevent crashes
- add type checking for returned modules before accessing properties
- update `todo_comments_nvim.lua` to use PascalCase color keys
