### PR TITLE
✨feat(nvim): add winmove.nvim and refactor plugin keymaps

### DIFF
--- a/configs/nvim/lua/plugins/editor/editing/dial_nvim.lua
+++ b/configs/nvim/lua/plugins/editor/editing/dial_nvim.lua
@@ -3,7 +3,22 @@ return {
 	{
 		"monaqa/dial.nvim",
 		lazy = true,
-		keys = { "<C-a>", "<C-x>" },
+		keys = {
+			{
+				"<C-a>",
+				function()
+					require("dial.map").manipulate("increment", "normal")
+				end,
+				desc = "dial: increment",
+			},
+			{
+				"<C-x>",
+				function()
+					require("dial.map").manipulate("decrement", "normal")
+				end,
+				desc = "dial: decrement",
+			},
+		},
 		config = function()
 			-- dial.nvim config
 			require("dial.config").augends:register_group({
@@ -22,19 +37,6 @@ return {
 					require("dial.augend").date.alias["%m月%d日"],
 				},
 			})
-			-- keymaps
-			vim.keymap.set(
-				"n",
-				"<C-a>",
-				require("dial.map").inc_normal(),
-				{ desc = "dial increment", silent = true, noremap = true }
-			)
-			vim.keymap.set(
-				"n",
-				"<C-x>",
-				require("dial.map").dec_normal(),
-				{ desc = "dial decrement", silent = true, noremap = true }
-			)
 		end,
 	},
 }

--- a/configs/nvim/lua/plugins/editor/motion/nvim_treehopper.lua
+++ b/configs/nvim/lua/plugins/editor/motion/nvim_treehopper.lua
@@ -3,13 +3,15 @@ return {
 	{
 		"mfussenegger/nvim-treehopper",
 		lazy = true,
-		keys = { "zf" },
-		config = function()
-			-- keymaps
-			vim.keymap.set("n", "zf", function()
-				require("tsht").nodes()
-				vim.cmd("normal! zf")
-			end, { desc = "treehopper", silent = true })
-		end,
+		keys = {
+			{
+				"zf",
+				function()
+					require("tsht").nodes()
+					vim.cmd("normal! zf")
+				end,
+				desc = "treehopper: fold with treesitter",
+			},
+		},
 	},
 }

--- a/configs/nvim/lua/plugins/editor/navigation/winmove_nvim.lua
+++ b/configs/nvim/lua/plugins/editor/navigation/winmove_nvim.lua
@@ -1,0 +1,33 @@
+-- window resize, move, and swap modes
+return {
+	{
+		"MisanthropicBit/winmove.nvim",
+		lazy = true,
+		keys = {
+			{
+				"<C-w>r",
+				function()
+					require("winmove").start_mode("resize")
+				end,
+				desc = "window: resize mode",
+			},
+			{
+				"<C-w>m",
+				function()
+					require("winmove").start_mode("move")
+				end,
+				desc = "window: move mode",
+			},
+			{
+				"<C-w>x",
+				function()
+					require("winmove").start_mode("swap")
+				end,
+				desc = "window: swap mode",
+			},
+		},
+		config = function()
+			require("winmove").setup()
+		end,
+	},
+}

--- a/configs/nvim/lua/plugins/editor/navigation/winpick_nvim.lua
+++ b/configs/nvim/lua/plugins/editor/navigation/winpick_nvim.lua
@@ -3,7 +3,41 @@ return {
 	{
 		"gbrlsnchs/winpick.nvim",
 		lazy = true,
-		keys = { "<C-w><C-w>" },
+		keys = {
+			{
+				"<C-w><C-w>",
+				function()
+					-- check if there are enough windows to pick from
+					local all_win_ids = vim.api.nvim_tabpage_list_wins(0)
+					local excluded_win_count = 0
+					for _, winid in ipairs(all_win_ids) do
+						local bufnr = vim.api.nvim_win_get_buf(winid)
+						local filetype = vim.bo[bufnr].filetype
+						if filetype == "noice" then
+							excluded_win_count = excluded_win_count + 1
+						end
+					end
+					-- if there are not enough windows, use the default behavior
+					local total_win_count = #all_win_ids
+					local eligible_win_count = total_win_count - excluded_win_count
+					if eligible_win_count < 3 then
+						-- if there are not enough windows, use the default behavior
+						vim.api.nvim_feedkeys(
+							vim.api.nvim_replace_termcodes("<C-w><C-w>", true, false, true),
+							"n",
+							true
+						)
+					else
+						-- if there are enough windows, use winpick
+						local success, winid = pcall(require("winpick").select)
+						if success and winid then
+							vim.api.nvim_set_current_win(winid)
+						end
+					end
+				end,
+				desc = "window: pick",
+			},
+		},
 		config = function()
 			-- winpick.nvim config
 			require("winpick").setup({
@@ -25,39 +59,6 @@ return {
 					return not is_excluded
 				end,
 			})
-			-- define the function to pick windows
-			_G.WinPick = function()
-				-- check if there are enough windows to pick from
-				local all_win_ids = vim.api.nvim_tabpage_list_wins(0)
-				local excluded_win_count = 0
-				for _, winid in ipairs(all_win_ids) do
-					local bufnr = vim.api.nvim_win_get_buf(winid)
-					local filetype = vim.bo[bufnr].filetype
-					if filetype == "noice" then
-						excluded_win_count = excluded_win_count + 1
-					end
-				end
-				-- if there are not enough windows, use the default behavior
-				local total_win_count = #all_win_ids
-				local eligible_win_count = total_win_count - excluded_win_count
-				if eligible_win_count < 3 then
-					-- if there are not enough windows, use the default behavior
-					vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes("<C-w><C-w>", true, false, true), "n", true)
-				else
-					-- if there are enough windows, use winpick
-					local success, winid = pcall(require("winpick").select)
-					if success and winid then
-						vim.api.nvim_set_current_win(winid)
-					end
-				end
-			end
-			-- keymaps
-			vim.api.nvim_set_keymap(
-				"n",
-				"<C-w><C-w>",
-				"<CMD>lua WinPick()<CR>",
-				{ desc = "pick windows", silent = true, noremap = true }
-			)
 		end,
 	},
 }

--- a/configs/nvim/lua/plugins/tools/internal/toggleterm_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/internal/toggleterm_nvim.lua
@@ -12,30 +12,42 @@ return {
 			"ToggleTermSendVisualLines",
 			"ToggleTermSendVisualSelection",
 		},
-		keys = { "g", "<LEADER>gg", "<LEADER>ts", "<LEADER>tv" },
-		init = function()
-			-- define the function to toggle lazygit
-			_G.ToggleLazyGit = function()
-				local Terminal = require("toggleterm.terminal").Terminal
-				local lazygit = Terminal:new({
-					cmd = "lazygit",
-					hidden = true,
-					direction = "float",
-					float_opts = {
-						border = "none",
-						width = 100000,
-						height = 100000,
-						zindex = 200,
-					},
-					on_open = function(_)
-						vim.cmd("startinsert!")
-					end,
-					on_close = function(_) end,
-					count = 99,
-				})
-				lazygit:toggle()
-			end
-		end,
+		keys = {
+			{
+				"<LEADER>gg",
+				function()
+					local Terminal = require("toggleterm.terminal").Terminal
+					local lazygit = Terminal:new({
+						cmd = "lazygit",
+						hidden = true,
+						direction = "float",
+						float_opts = {
+							border = "none",
+							width = 100000,
+							height = 100000,
+							zindex = 200,
+						},
+						on_open = function(_)
+							vim.cmd("startinsert!")
+						end,
+						on_close = function(_) end,
+						count = 99,
+					})
+					lazygit:toggle()
+				end,
+				desc = "git: lazygit",
+			},
+			{
+				"<LEADER>ts",
+				"<CMD>ToggleTerm direction=horizontal<CR>",
+				desc = "terminal: horizontal",
+			},
+			{
+				"<LEADER>tv",
+				"<CMD>ToggleTerm direction=vertical<CR>",
+				desc = "terminal: vertical",
+			},
+		},
 		config = function()
 			-- toggleterm.nvim config
 			require("toggleterm").setup({
@@ -55,26 +67,7 @@ return {
 					NormalNC = { link = "TerminalNormal" },
 				},
 			})
-			-- keymaps
-			-- to avoid not opening terminal after opened and exited, set keymaps here again
-			vim.keymap.set(
-				"n",
-				"<LEADER>gg",
-				"<CMD>lua ToggleLazyGit()<CR>",
-				{ desc = "lazygit", silent = true, noremap = true }
-			)
-			vim.keymap.set(
-				"n",
-				"<LEADER>ts",
-				"<CMD>ToggleTerm direction=horizontal<CR>",
-				{ desc = "terminal: horizontal", silent = true, noremap = true }
-			)
-			vim.keymap.set(
-				"n",
-				"<LEADER>tv",
-				"<CMD>ToggleTerm direction=vertical<CR>",
-				{ desc = "terminal: vertical", silent = true, noremap = true }
-			)
+			-- terminal mode keymaps
 			vim.keymap.set("t", "<ESC><ESC>", [[<C-\><C-n>]], { noremap = true })
 			vim.keymap.set("t", "<C-h>", [[<C-\><C-n><C-w>h]], { noremap = true, silent = true })
 			vim.keymap.set("t", "<C-j>", [[<C-\><C-n><C-w>j]], { noremap = true, silent = true })


### PR DESCRIPTION
- add `winmove.nvim` for window resize, move, and swap modes
- refactor `keys` configuration to use structured table format
  with callback functions and `desc` for `which-key` integration
- apply consistent pattern to `dial.nvim`, `nvim-treehopper`,
  `winpick.nvim`, and `toggleterm.nvim`
- remove global functions (`_G.WinPick`, `_G.ToggleLazyGit`) and
  `init` hooks in favor of inline callbacks
- fix `dial.nvim` to use `manipulate()` api instead of `inc_normal()`
