### PR TITLE
🐞fix(nvim): set terminal bright black for autosuggestions

### DIFF
--- a/configs/nvim/lua/plugins/ui/colorscheme/everforest_nvim.lua
+++ b/configs/nvim/lua/plugins/ui/colorscheme/everforest_nvim.lua
@@ -13,6 +13,8 @@ return {
 				end,
 			})
 			vim.cmd("colorscheme everforest")
+			-- terminal bright black for zsh-autosuggestions
+			vim.g.terminal_color_8 = "#5C6A72"
 		end,
 	},
 }


### PR DESCRIPTION
- add `terminal_color_8` to match WezTerm everforest dark medium theme
- fix zsh-autosuggestions visibility in neovim terminal
