### PR TITLE
🧹chore(package-managers): remove `kiro` from winget and brew

### DIFF
--- a/ops/package-managers/winget/packages.json
+++ b/ops/package-managers/winget/packages.json
@@ -14,9 +14,6 @@
           "PackageIdentifier": "Amazon.Kindle"
         },
         {
-          "PackageIdentifier": "Amazon.Kiro"
-        },
-        {
           "PackageIdentifier": "Apple.Bonjour"
         },
         {

--- a/outputs/darwin/shared-modules/brew.nix
+++ b/outputs/darwin/shared-modules/brew.nix
@@ -34,7 +34,6 @@
       "hiddenbar"
       "homerow"
       "karabiner-elements"
-      "kiro"
       "libreoffice"
       "libreoffice-language-pack"
       "mediosz/tap/swipeaerospace"


### PR DESCRIPTION
- remove `Amazon.Kiro` from winget packages
- remove `kiro` from brew casks
