### PR TITLE
🔧refactor(nvim): replace marksman with markdown-oxide

### DIFF
--- a/configs/nvim/lua/plugins/editor/navigation/winmove_nvim.lua
+++ b/configs/nvim/lua/plugins/editor/navigation/winmove_nvim.lua
@@ -27,7 +27,7 @@ return {
 			},
 		},
 		config = function()
-			require("winmove").setup()
+			require("winmove").configure()
 		end,
 	},
 }

--- a/configs/nvim/lua/plugins/languages/lsp/utils/server_list.lua
+++ b/configs/nvim/lua/plugins/languages/lsp/utils/server_list.lua
@@ -13,15 +13,10 @@ M.servers = {
 	-- go
 	"golangci_lint_ls",
 	"gopls",
-	-- web
-	"astro",
-	"cssls",
-	"html",
-	"jsonls",
-	-- markdown
-	"marksman",
 	-- lua
 	"lua_ls",
+	-- markdown
+	"markdown_oxide",
 	-- nix
 	"nil_ls",
 	-- rust
@@ -32,11 +27,16 @@ M.servers = {
 	"sqlls",
 	-- tailwind
 	"tailwindcss",
+	-- toml
+	"taplo",
 	-- typescript
 	"denols",
 	"ts_ls",
-	-- toml
-	"taplo",
+	-- web
+	"astro",
+	"cssls",
+	"html",
+	"jsonls",
 	-- yaml
 	"yamlls",
 }


### PR DESCRIPTION
- replace `marksman` LSP with `markdown_oxide` for markdown files
- fix `winmove.nvim` setup function from `setup()` to `configure()`
- reorder LSP server list alphabetically (excluding common section)
