### PR TITLE
✨feat(nvim): migrate nvim-treesitter to main branch API

### DIFF
--- a/configs/nvim/lua/plugins/editor/editing/vim_matchup.lua
+++ b/configs/nvim/lua/plugins/editor/editing/vim_matchup.lua
@@ -6,8 +6,8 @@ return {
 		event = { "BufReadPost", "BufNewFile" },
 		config = function()
 			-- vim-matchup config
-			require("nvim-treesitter.configs").setup({
-				matchup = {
+			require("match-up").setup({
+				treesitter = {
 					enable = true,
 				},
 			})

--- a/configs/nvim/lua/plugins/languages/lsp/config/nvim_treesitter.lua
+++ b/configs/nvim/lua/plugins/languages/lsp/config/nvim_treesitter.lua
@@ -3,77 +3,70 @@ return {
 	{
 		"nvim-treesitter/nvim-treesitter",
 		lazy = false,
+		build = ":TSUpdate",
 		config = function()
-			-- nvim-treesitter config
-			require("nvim-treesitter.configs").setup({
-				highlight = {
-					enable = true,
-					additional_vim_regex_highlighting = false,
-				},
-				incremental_selection = {
-					enable = true,
-				},
-				indent = {
-					enable = true,
-				},
-				ensure_installed = {
-					-- common
-					"comment",
-					"diff",
-					"git_config",
-					"git_rebase",
-					"gitattributes",
-					"gitcommit",
-					"gitignore",
-					"ini",
-					"regex",
-					-- astro
-					"astro",
-					-- bash
-					"bash",
-					-- css
-					"css",
-					-- docker
-					"dockerfile",
-					-- go
-					"go",
-					"gomod",
-					"gosum",
-					-- hrml
-					"html",
-					-- javascript
-					"javascript",
-					"jsdoc",
-					-- json
-					"jsonc",
-					"json",
-					-- lua
-					"lua",
-					-- markdown
-					"markdown",
-					"markdown_inline",
-					-- make
-					"make",
-					-- nix
-					"nix",
-					-- rust
-					"rust",
-					-- scss
-					"scss",
-					-- sql
-					"sql",
-					-- toml
-					"toml",
-					-- typescript
-					"tsx",
-					-- typescript
-					"typescript",
-					-- yaml
-					"yaml",
-				},
-				ignore_install = {
-					"org",
-				},
+			local ts = require("nvim-treesitter")
+			local ensure_installed = {
+				-- common
+				"comment",
+				"diff",
+				"git_config",
+				"git_rebase",
+				"gitattributes",
+				"gitcommit",
+				"gitignore",
+				"ini",
+				"regex",
+				-- docker
+				"dockerfile",
+				-- go
+				"go",
+				"gomod",
+				"gosum",
+				-- lua
+				"lua",
+				-- make
+				"make",
+				-- markdown
+				"markdown",
+				"markdown_inline",
+				-- nix
+				"nix",
+				-- rust
+				"rust",
+				-- shell
+				"bash",
+				-- sql
+				"sql",
+				-- toml
+				"toml",
+				-- typescript
+				"javascript",
+				"jsdoc",
+				"tsx",
+				"typescript",
+				-- web
+				"astro",
+				"css",
+				"html",
+				"json",
+				"jsonc",
+				"scss",
+				-- yaml
+				"yaml",
+			}
+			-- check for installed parsers and install missing ones
+			local installed = ts.get_installed()
+			local missing = vim.tbl_filter(function(p)
+				return not vim.tbl_contains(installed, p)
+			end, ensure_installed)
+			if #missing > 0 then
+				ts.install(missing)
+			end
+			vim.api.nvim_create_autocmd("FileType", {
+				callback = function()
+					pcall(vim.treesitter.start)
+				end,
 			})
 		end,
 	},

--- a/outputs/home-manager/shared-modules/cli/editor.nix
+++ b/outputs/home-manager/shared-modules/cli/editor.nix
@@ -6,6 +6,7 @@
     packages = with pkgs; [
       helix
       neovim
+      tree-sitter
       vim
     ];
   };


### PR DESCRIPTION
- update `nvim-treesitter` config to use new main branch API
- replace `require("nvim-treesitter.configs")` with `require("nvim-treesitter")`
- add `build = ":TSUpdate"` for automatic parser updates
- check installed parsers before installing to avoid reinstallation
- enable treesitter highlighting via `FileType` autocmd
- update `vim-matchup` to use `require("match-up").setup()`
- add `tree-sitter` CLI to nix packages (required for main branch)
