### PR TITLE
🔧refactor(nix): remove `emrldnix/wrangler` flake input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,27 +57,6 @@
         "type": "github"
       }
     },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "wrangler",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1765835352,
-        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "gitlogue": {
       "inputs": {
         "nixpkgs": [
@@ -219,8 +198,7 @@
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_2",
         "sops-nix": "sops-nix",
-        "treefmt-nix": "treefmt-nix",
-        "wrangler": "wrangler"
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "rust-analyzer-src": {
@@ -295,27 +273,6 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "wrangler": {
-      "inputs": {
-        "flake-parts": "flake-parts",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1766180048,
-        "narHash": "sha256-wtoMuR1eXI0VQajyIidzXUUQ7j2ZYBMd/dV3tn5y6C0=",
-        "owner": "emrldnix",
-        "repo": "wrangler",
-        "rev": "ad41d22ba2258d2516ba9d9a471ec0e24534eb95",
-        "type": "github"
-      },
-      "original": {
-        "owner": "emrldnix",
-        "repo": "wrangler",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -83,15 +83,6 @@
         };
       };
     };
-    ## wrangler
-    wrangler = {
-      url = "github:emrldnix/wrangler";
-      inputs = {
-        nixpkgs = {
-          follows = "nixpkgs";
-        };
-      };
-    };
   };
   outputs = inputs: {
     # nixos

--- a/outputs/nixos/shared-modules/nix.nix
+++ b/outputs/nixos/shared-modules/nix.nix
@@ -19,13 +19,11 @@
       substituters = [
         "https://cache.nixos.org"
         "https://nix-community.cachix.org"
-        "https://wrangler.cachix.org"
         "https://ai.cachix.org"
       ];
       trusted-public-keys = [
         "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-        "wrangler.cachix.org-1:N/FIcG2qBQcolSpklb2IMDbsfjZKWg+ctxx0mSMXdSs="
         "ai.cachix.org-1:N9dzRK+alWwoKXQlnn0H6aUx0lU/mspIoz8hMvGvbbc="
       ];
       trusted-users = [

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -105,8 +105,4 @@ inputs: [
   (final: prev: {
     mediaplayer = inputs.mediaplayer.packages.${prev.stdenv.hostPlatform.system}.default;
   })
-  ## wrangler
-  (final: prev: {
-    wrangler = inputs.wrangler.packages.${prev.stdenv.hostPlatform.system}.default;
-  })
 ]


### PR DESCRIPTION
- remove `wrangler` input from `flake.nix`
- remove `flake-parts` and `wrangler` entries from `flake.lock`
- remove wrangler overlay from `overlays/default.nix`
- remove `wrangler.cachix.org` from nix substituters and trusted keys
- use nixpkgs standard `wrangler` package instead
