### PR TITLE
🔧refactor(nvim): replace deprecated `TSUpdateSync` with `TSUpdate`

### DIFF
--- a/configs/nvim/lua/plugins/ui/components/alpha_nvim.lua
+++ b/configs/nvim/lua/plugins/ui/components/alpha_nvim.lua
@@ -97,7 +97,7 @@ return {
 				dashboard.button("g", icons.git.Git .. "  lazygit", "<CMD>lua ToggleLazyGit()<CR>"),
 				dashboard.button("l", icons.misc.Lazy .. "  lazy", "<CMD>Lazy<CR>"),
 				dashboard.button("m", icons.misc.Mason .. "  mason lsp", "<CMD>Mason<CR>"),
-				dashboard.button("T", icons.ui.Tree .. "  sync tree-sitter parser", "<CMD>TSUpdateSync<CR>"),
+				dashboard.button("T", icons.ui.Tree .. "  sync tree-sitter parser", "<CMD>TSUpdate<CR>"),
 				dashboard.button("q", icons.ui.Close .. "  quit", "<CMD>quit<CR>"),
 			}
 			-- layout


### PR DESCRIPTION
- update `alpha-nvim` dashboard button to use `TSUpdate` command
- `TSUpdateSync` was removed in `nvim-treesitter` main branch rewrite
