### PR TITLE
✨feat(hammerspoon): add watcher to restart SwipeAeroSpace on wake

### DIFF
--- a/configs/hammerspoon/config/watcher.lua
+++ b/configs/hammerspoon/config/watcher.lua
@@ -1,0 +1,17 @@
+-- watcher
+---- restart SwipeAeroSpace on wake/unlock events
+hs.caffeinate.watcher
+	.new(function(event)
+		local wakeEvents = {
+			[hs.caffeinate.watcher.systemDidWake] = true,
+			[hs.caffeinate.watcher.screensDidWake] = true,
+			[hs.caffeinate.watcher.screensaverDidStop] = true,
+			[hs.caffeinate.watcher.screensaverWillStop] = true,
+			[hs.caffeinate.watcher.sessionDidBecomeActive] = true,
+		}
+		if wakeEvents[event] then
+			hs.execute("/usr/bin/killall -9 SwipeAeroSpace 2>/dev/null", true)
+			hs.execute("/usr/bin/open -a SwipeAeroSpace", true)
+		end
+	end)
+	:start()

--- a/configs/hammerspoon/init.lua
+++ b/configs/hammerspoon/init.lua
@@ -5,3 +5,5 @@ require("config.keymaps")
 require("config.open")
 -- apps
 require("config.apps")
+-- watcher
+require("config.watcher")


### PR DESCRIPTION
- add `watcher.lua` to monitor sleep/wake events using
  `hs.caffeinate.watcher`
- restart `SwipeAeroSpace` on `systemDidWake`, `screensDidWake`,
  `screensaverDidStop`, `screensaverWillStop`, and
  `sessionDidBecomeActive` events
- force kill with `SIGKILL` before relaunch to ensure clean restart
