### PR TITLE
⚡perf(nvim): remove delay for `which-key` popup

### DIFF
--- a/configs/nvim/lua/plugins/tools/internal/which_key_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/internal/which_key_nvim.lua
@@ -8,7 +8,7 @@ return {
 			-- which-key.nvim config
 			require("which-key").setup({
 				preset = "modern",
-				delay = 500,
+				delay = 0,
 				sort = { "local", "order", "alphanum", "mod" },
 			})
 			-- which-key mappings (start with <LEADER>)


### PR DESCRIPTION
- set `delay` to `0` for immediate popup display
