### PR TITLE
🔧refactor(zsh): use `programs.zsh.dotDir` for xdg config

### DIFF
--- a/configs/default.nix
+++ b/configs/default.nix
@@ -4,17 +4,6 @@
   ...
 }:
 let
-  # regular config files (excluding default.nix and ai directory)
-  contents = builtins.readDir ./.;
-  filteredContents = lib.filterAttrs (name: _: name != "default.nix" && name != "ai") contents;
-  mkEntry = name: type: {
-    name = name;
-    value = {
-      source = ./. + "/${name}";
-      recursive = type == "directory";
-    };
-  };
-  configFiles = lib.mapAttrs' mkEntry filteredContents;
   # local ai commands
   localAiCommands = builtins.readDir ./ai/commands;
   # create ai-related configuration entries
@@ -26,6 +15,19 @@ let
         source = ./ai/commands + "/${name}";
       };
     }) localAiCommands;
+  # regular config files (excluding default.nix, ai, and zsh directories)
+  contents = builtins.readDir ./.;
+  filteredContents = lib.filterAttrs (
+    name: _: name != "default.nix" && name != "ai" && name != "zsh"
+  ) contents;
+  mkEntry = name: type: {
+    name = name;
+    value = {
+      source = ./. + "/${name}";
+      recursive = type == "directory";
+    };
+  };
+  configFiles = lib.mapAttrs' mkEntry filteredContents;
   # hypr config files with custom onChange hook for hyprland.conf
   hyprConfigEntries = {
     "hypr/hyprland.conf" = {
@@ -48,10 +50,19 @@ let
     "hypr/hyprlock.conf".source = ./hypr/hyprlock.conf;
     "hypr/hyprpaper.conf".source = ./hypr/hyprpaper.conf;
   };
+  # zsh config subdirectories (excluding .zshrc/.zshenv which are managed by programs.zsh)
+  zshContents = builtins.readDir ./zsh;
+  zshConfigEntries = lib.mapAttrs' (name: type: {
+    name = "zsh/${name}";
+    value = {
+      source = ./zsh + "/${name}";
+      recursive = type == "directory";
+    };
+  }) zshContents;
 in
 {
   # xdg
   xdg = {
-    configFile = configFiles // aiConfigEntries // hyprConfigEntries;
+    configFile = configFiles // aiConfigEntries // hyprConfigEntries // zshConfigEntries;
   };
 }

--- a/configs/zsh/env/init.zsh
+++ b/configs/zsh/env/init.zsh
@@ -1,5 +1,5 @@
 #
-# .zshenv - zsh environment file
+# init.zsh - zsh environment file
 # loaded for all zsh sessions (login, interactive, non-interactive)
 #
 

--- a/configs/zsh/rc/init.zsh
+++ b/configs/zsh/rc/init.zsh
@@ -1,5 +1,5 @@
 #
-# .zshrc - zsh interactive shell configuration
+# init.zsh - zsh interactive shell configuration
 # loaded for interactive zsh sessions
 #
 

--- a/outputs/darwin/yanoMac/home.nix
+++ b/outputs/darwin/yanoMac/home.nix
@@ -16,9 +16,6 @@
   home = {
     enableNixpkgsReleaseCheck = true;
     homeDirectory = "${homePath}/${username}";
-    sessionVariables = {
-      ZDOTDIR = "${config.xdg.configHome}/zsh";
-    };
     stateVersion = "24.05"; # DO NOT CHANGE
     username = username;
   };

--- a/outputs/darwin/yanoMacBook/home.nix
+++ b/outputs/darwin/yanoMacBook/home.nix
@@ -16,9 +16,6 @@
   home = {
     enableNixpkgsReleaseCheck = true;
     homeDirectory = "${homePath}/${username}";
-    sessionVariables = {
-      ZDOTDIR = "${config.xdg.configHome}/zsh";
-    };
     stateVersion = "24.05"; # DO NOT CHANGE
     username = username;
   };

--- a/outputs/home-manager/shared-modules/cli/shell.nix
+++ b/outputs/home-manager/shared-modules/cli/shell.nix
@@ -48,6 +48,9 @@ in
         };
         zsh = {
           enable = true;
+          dotDir = "${config.xdg.configHome}/zsh";
+          envExtra = ''source "$ZDOTDIR/env/init.zsh"'';
+          initContent = ''source "$ZDOTDIR/rc/init.zsh"'';
         };
       };
     }

--- a/outputs/nixos/yanoNixOs/home.nix
+++ b/outputs/nixos/yanoNixOs/home.nix
@@ -18,9 +18,6 @@
   home = {
     enableNixpkgsReleaseCheck = true;
     homeDirectory = "${homePath}/${username}";
-    sessionVariables = {
-      ZDOTDIR = "${config.xdg.configHome}/zsh";
-    };
     stateVersion = "24.05"; # DO NOT CHANGE
     username = username;
   };

--- a/outputs/nixos/yanoNixOsWsl/home.nix
+++ b/outputs/nixos/yanoNixOsWsl/home.nix
@@ -18,9 +18,6 @@
   home = {
     enableNixpkgsReleaseCheck = true;
     homeDirectory = "${homePath}/${username}";
-    sessionVariables = {
-      ZDOTDIR = "${config.xdg.configHome}/zsh";
-    };
     stateVersion = "24.05"; # DO NOT CHANGE
     username = username;
   };


### PR DESCRIPTION
- rename `.zshenv` to `env/init.zsh` and `.zshrc` to `rc/init.zsh`
- add `dotDir`, `envExtra`, `initContent` to home-manager zsh config
- update `configs/default.nix` to deploy zsh subdirectories separately
- remove manual `ZDOTDIR` session variable from all `home.nix` files
- reorder let bindings alphabetically in `configs/default.nix`
