### PR TITLE
🐞fix:(nvim) remove `jsonc` from treesitter ensure_installed

### DIFF
--- a/configs/nvim/lua/plugins/languages/lsp/config/nvim_treesitter.lua
+++ b/configs/nvim/lua/plugins/languages/lsp/config/nvim_treesitter.lua
@@ -50,7 +50,6 @@ return {
 				"css",
 				"html",
 				"json",
-				"jsonc",
 				"scss",
 				-- yaml
 				"yaml",


### PR DESCRIPTION
- remove `jsonc` from `ensure_installed` list in `nvim_treesitter.lua`
- `jsonc` parser was removed in nvim-treesitter/nvim-treesitter#8316
- `json` parser now handles `.jsonc` files natively
