### PR TITLE
✨feat:(nix) optimize flakes and cachix for AI tools

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,24 @@
 {
   "nodes": {
+    "claude-code": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1766457259,
+        "narHash": "sha256-bDA65v40vYio865H6UplNHbeYhR7/A1GQqKT1u3suAM=",
+        "owner": "sadjow",
+        "repo": "claude-code-nix",
+        "rev": "5dfa1244dd5e93dd868719e26d80164dd3b0ba00",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sadjow",
+        "repo": "claude-code-nix",
+        "type": "github"
+      }
+    },
     "darwin": {
       "inputs": {
         "nixpkgs": [
@@ -54,6 +73,45 @@
       "original": {
         "owner": "edolstra",
         "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "wrangler",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765835352,
+        "narHash": "sha256-XswHlK/Qtjasvhd1nOa1e8MgZ8GS//jBoTqWtrS1Giw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "a34fae9c08a15ad73f295041fec82323541400a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -157,6 +215,22 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1766314097,
+        "narHash": "sha256-laJftWbghBehazn/zxVJ8NdENVgjccsWAdAqKXhErrM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "306ea70f9eb0fb4e040f8540e2deab32ed7e2055",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
@@ -171,7 +245,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1767116409,
         "narHash": "sha256-5vKw92l1GyTnjoLzEagJy5V5mDFck72LiQWZSOnSicw=",
@@ -189,6 +263,7 @@
     },
     "root": {
       "inputs": {
+        "claude-code": "claude-code",
         "darwin": "darwin",
         "fenix": "fenix",
         "gitlogue": "gitlogue",
@@ -196,9 +271,10 @@
         "mediaplayer": "mediaplayer",
         "nixos-hardware": "nixos-hardware",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "sops-nix": "sops-nix",
-        "treefmt-nix": "treefmt-nix"
+        "treefmt-nix": "treefmt-nix",
+        "wrangler": "wrangler"
       }
     },
     "rust-analyzer-src": {
@@ -220,7 +296,7 @@
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1764038373,
@@ -256,6 +332,21 @@
         "type": "github"
       }
     },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -273,6 +364,27 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "wrangler": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1766275271,
+        "narHash": "sha256-Flsx7qIbpgmZsfdMCLN6e3KYfqrVlrv1jr7CW65bEog=",
+        "owner": "emrldnix",
+        "repo": "wrangler",
+        "rev": "b07e25122007faad139203c6f4a5688f2e436105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "emrldnix",
+        "repo": "wrangler",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,10 @@
       };
     };
     # packages
+    ## claude-code
+    claude-code = {
+      url = "github:sadjow/claude-code-nix";
+    };
     ## gitlogue
     gitlogue = {
       url = "github:unhappychoice/gitlogue";
@@ -77,6 +81,15 @@
     ## treefmt-nix
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
+      inputs = {
+        nixpkgs = {
+          follows = "nixpkgs";
+        };
+      };
+    };
+    ## wrangler
+    wrangler = {
+      url = "github:emrldnix/wrangler";
       inputs = {
         nixpkgs = {
           follows = "nixpkgs";

--- a/outputs/darwin/shared-modules/nix.nix
+++ b/outputs/darwin/shared-modules/nix.nix
@@ -20,11 +20,15 @@
       ];
       substituters = [
         "https://cache.nixos.org"
+        "https://claude-code.cachix.org"
         "https://nix-community.cachix.org"
+        "https://wrangler.cachix.org"
       ];
       trusted-public-keys = [
         "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+        "claude-code.cachix.org-1:YeXf2aNu7UTX8Vwrze0za1WEDS+4DuI2kVeWEE4fsRk="
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+        "wrangler.cachix.org-1:N/FIcG2qBQcolSpklb2IMDbsfjZKWg+ctxx0mSMXdSs="
       ];
       trusted-users = [
         "root"

--- a/outputs/home-manager/shared-modules/cli/ai.nix
+++ b/outputs/home-manager/shared-modules/cli/ai.nix
@@ -5,7 +5,7 @@
   home = {
     packages = with pkgs; [
       claude-code
-      gemini-cli
+      gemini-cli-bin
       spec-kit
     ];
   };

--- a/outputs/home-manager/shared-modules/cli/shell.nix
+++ b/outputs/home-manager/shared-modules/cli/shell.nix
@@ -29,7 +29,6 @@ in
       # home
       home = {
         packages = with pkgs; [
-          inshellisense
           sheldon
           starship
           tmux

--- a/outputs/nixos/shared-modules/nix.nix
+++ b/outputs/nixos/shared-modules/nix.nix
@@ -18,13 +18,19 @@
       ];
       substituters = [
         "https://cache.nixos.org"
+        "https://claude-code.cachix.org"
+        "https://cuda-maintainers.cachix.org"
+        "https://hyprland.cachix.org"
         "https://nix-community.cachix.org"
-        "https://ai.cachix.org"
+        "https://wrangler.cachix.org"
       ];
       trusted-public-keys = [
         "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+        "claude-code.cachix.org-1:YeXf2aNu7UTX8Vwrze0za1WEDS+4DuI2kVeWEE4fsRk="
+        "cuda-maintainers.cachix.org-1:0dq3bujKpuEPMCX6U4WylrUDZ9JyUG0VpVZa7CNfq5E="
+        "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-        "ai.cachix.org-1:N9dzRK+alWwoKXQlnn0H6aUx0lU/mspIoz8hMvGvbbc="
+        "wrangler.cachix.org-1:N/FIcG2qBQcolSpklb2IMDbsfjZKWg+ctxx0mSMXdSs="
       ];
       trusted-users = [
         "root"

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -54,6 +54,10 @@ inputs: [
       };
     }
   )
+  ## claude-code
+  (final: prev: {
+    claude-code = inputs.claude-code.packages.${prev.stdenv.hostPlatform.system}.default;
+  })
   ## gitlogue
   (final: prev: {
     gitlogue = inputs.gitlogue.packages.${prev.stdenv.hostPlatform.system}.default;
@@ -104,5 +108,9 @@ inputs: [
   ## mediaplayer
   (final: prev: {
     mediaplayer = inputs.mediaplayer.packages.${prev.stdenv.hostPlatform.system}.default;
+  })
+  ## wrangler
+  (final: prev: {
+    wrangler = inputs.wrangler.packages.${prev.stdenv.hostPlatform.system}.wrangler;
   })
 ]


### PR DESCRIPTION
- add `claude-code` flake from `sadjow/claude-code-nix` for faster
updates
- add `wrangler` flake from `emrldnix/wrangler` with cachix support
- change `gemini-cli` to `gemini-cli-bin` to avoid npm build issues
- remove `inshellisense` due to node.js 24 incompatibility
- remove `ai.cachix.org`
- add `claude-code.cachix.org` for pre-built binaries
- add `cuda-maintainers.cachix.org` for `comfyui`/`invokeai`
- add `hyprland.cachix.org` for `hyprland` wm
- add `wrangler.cachix.org` for `wrangler` builds
- add overlays for `claude-code` and `wrangler`
