### PR TITLE
🧹chore:(nix) pin flake inputs to explicit branch refs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,7 @@
       },
       "original": {
         "owner": "sadjow",
+        "ref": "main",
         "repo": "claude-code-nix",
         "type": "github"
       }
@@ -28,13 +29,14 @@
       "locked": {
         "lastModified": 1767028240,
         "narHash": "sha256-0/fLUqwJ4Z774muguUyn5t8AQ6wyxlNbHexpje+5hRo=",
-        "owner": "lnl7",
+        "owner": "nix-darwin",
         "repo": "nix-darwin",
         "rev": "c31afa6e76da9bbc7c9295e39c7de9fca1071ea1",
         "type": "github"
       },
       "original": {
-        "owner": "lnl7",
+        "owner": "nix-darwin",
+        "ref": "master",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -56,6 +58,7 @@
       },
       "original": {
         "owner": "nix-community",
+        "ref": "main",
         "repo": "fenix",
         "type": "github"
       }
@@ -132,6 +135,7 @@
       },
       "original": {
         "owner": "unhappychoice",
+        "ref": "main",
         "repo": "gitlogue",
         "type": "github"
       }
@@ -152,6 +156,7 @@
       },
       "original": {
         "owner": "nix-community",
+        "ref": "master",
         "repo": "home-manager",
         "type": "github"
       }
@@ -172,6 +177,7 @@
       },
       "original": {
         "owner": "nomisreual",
+        "ref": "main",
         "repo": "mediaplayer",
         "type": "github"
       }
@@ -209,6 +215,7 @@
       },
       "original": {
         "owner": "nix-community",
+        "ref": "main",
         "repo": "NixOS-WSL",
         "type": "github"
       }
@@ -247,16 +254,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1767379071,
-        "narHash": "sha256-EgE0pxsrW9jp9YFMkHL9JMXxcqi/OoumPJYwf+Okucw=",
+        "lastModified": 1767546459,
+        "narHash": "sha256-I7zgkW2sXFLAAbFjiJIhwgEzp+WzjBEcpRHspP2w8oQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fb7944c166a3b630f177938e478f0378e64ce108",
+        "rev": "59be811c906e989c64e7bcb4b7e2ca2546fe1440",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "master",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -328,6 +335,7 @@
       },
       "original": {
         "owner": "Mic92",
+        "ref": "master",
         "repo": "sops-nix",
         "type": "github"
       }
@@ -363,6 +371,7 @@
       },
       "original": {
         "owner": "numtide",
+        "ref": "main",
         "repo": "treefmt-nix",
         "type": "github"
       }
@@ -384,6 +393,7 @@
       },
       "original": {
         "owner": "emrldnix",
+        "ref": "master",
         "repo": "wrangler",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
   inputs = {
     # nixpkgs
     nixpkgs = {
-      url = "github:nixos/nixpkgs/nixos-unstable";
+      url = "github:nixos/nixpkgs/master";
     };
     # modules
     ## nixos hardware
@@ -12,7 +12,7 @@
     };
     ## nixos wsl
     nixos-wsl = {
-      url = "github:nix-community/NixOS-WSL";
+      url = "github:nix-community/NixOS-WSL/main";
       inputs = {
         nixpkgs = {
           follows = "nixpkgs";
@@ -21,7 +21,7 @@
     };
     ## darwin
     darwin = {
-      url = "github:lnl7/nix-darwin";
+      url = "github:nix-darwin/nix-darwin/master";
       inputs = {
         nixpkgs = {
           follows = "nixpkgs";
@@ -30,7 +30,7 @@
     };
     ## home-manager
     home-manager = {
-      url = "github:nix-community/home-manager";
+      url = "github:nix-community/home-manager/master";
       inputs = {
         nixpkgs = {
           follows = "nixpkgs";
@@ -39,7 +39,7 @@
     };
     ## rust
     fenix = {
-      url = "github:nix-community/fenix";
+      url = "github:nix-community/fenix/main";
       inputs = {
         nixpkgs = {
           follows = "nixpkgs";
@@ -48,7 +48,7 @@
     };
     ## sops-nix
     sops-nix = {
-      url = "github:Mic92/sops-nix";
+      url = "github:Mic92/sops-nix/master";
       inputs = {
         nixpkgs = {
           follows = "nixpkgs";
@@ -58,11 +58,11 @@
     # packages
     ## claude-code
     claude-code = {
-      url = "github:sadjow/claude-code-nix";
+      url = "github:sadjow/claude-code-nix/main";
     };
     ## gitlogue
     gitlogue = {
-      url = "github:unhappychoice/gitlogue";
+      url = "github:unhappychoice/gitlogue/main";
       inputs = {
         nixpkgs = {
           follows = "nixpkgs";
@@ -71,7 +71,7 @@
     };
     ## mediaplayer
     mediaplayer = {
-      url = "github:nomisreual/mediaplayer";
+      url = "github:nomisreual/mediaplayer/main";
       inputs = {
         nixpkgs = {
           follows = "nixpkgs";
@@ -80,7 +80,7 @@
     };
     ## treefmt-nix
     treefmt-nix = {
-      url = "github:numtide/treefmt-nix";
+      url = "github:numtide/treefmt-nix/main";
       inputs = {
         nixpkgs = {
           follows = "nixpkgs";
@@ -89,7 +89,7 @@
     };
     ## wrangler
     wrangler = {
-      url = "github:emrldnix/wrangler";
+      url = "github:emrldnix/wrangler/master";
       inputs = {
         nixpkgs = {
           follows = "nixpkgs";


### PR DESCRIPTION
- add explicit `ref` to all flake inputs for reproducibility
- change `nixpkgs` from `nixos-unstable` to `master`
- update `darwin` owner from `lnl7` to `nix-darwin`
- update `flake.lock` with new references
