### PR TITLE
🔧refactor(nix): replace `nixfmt-rfc-style` with `nixfmt`

### DIFF
--- a/outputs/home-manager/shared-modules/languages/nix.nix
+++ b/outputs/home-manager/shared-modules/languages/nix.nix
@@ -3,6 +3,6 @@
 {
   # home
   home = {
-    packages = with pkgs; [ nixfmt-rfc-style ];
+    packages = with pkgs; [ nixfmt ];
   };
 }


### PR DESCRIPTION
- use `nixfmt` instead of `nixfmt-rfc-style` as they are now identical
