### PR TITLE
✨feat:(jj) add jujutsu and lazyjj support

### DIFF
--- a/configs/claude/commands/csj.md
+++ b/configs/claude/commands/csj.md
@@ -1,0 +1,54 @@
+# Commit command for jj (Jujutsu)
+
+- Please generate a commit message in English for the current working copy changes.
+- Show the following commands for the user to run manually in order:
+  1. `gh issue create` command:
+     - title format: `(scope) description` (e.g., `(ai) expand workflow`)
+     - no body
+     - label: `bug` for `fix:` prefix, `enhancement` for others
+     - assignee: self (`@me`)
+  2. `jj describe` command with the generated message
+  3. `jj bookmark create` command to create a bookmark for the issue (e.g., `123-feature-name`)
+  4. `nix fmt` command to format files
+  5. `jj git push` command to push the changes to remote with `-b <bookmark> --allow-new`
+  6. `gh pr create` command:
+     - body: commit message body + `closes #<issue-number>` (use \`--body "$(jj log -r @- --no-graph -T description | tail -n +3)
+
+closes #<issue-number>"`)      - label: same as issue      - assignee: same as issue (`@me`)   7. `gh pr merge\` command to merge the pull request
+
+- Do not show the commit message separately; only show it in the commands.
+- Do not execute any commands, only show them for the user to run manually.
+
+## Rules
+
+1. The title should be at most 50 characters, and the body should be wrapped at 72 characters.
+   For the title, use one of the following prefixes, separated from the title by a space:
+
+   - `✨feat:` - Use for new feature additions
+   - `🐞fix:` - Use for bug fixes
+   - `📚docs:` - Use for documentation-only changes
+   - `💄style:` - Use for changes that do not affect program behavior (indentation adjustments, formatting, etc.)
+   - `🔧refactor:` - Use for code modifications other than bug fixes or feature additions
+   - `🚀perf:` - Use for code modifications aimed at performance improvements
+   - `🧪test:` - Use for adding tests or modifying existing tests
+   - `🧹chore:` - Use for changes to build process, auxiliary tools, or libraries
+   - `🔀merge:` - Use for merge commits
+
+2. Add () after prefix and fill it with the changed tool.
+   For example, if GitHub Workflow file was changed: (workflow)
+   If jj config file was changed: (jj)
+
+3. In the body, list the changes as bullet points, each starting with "- ".
+
+4. Leave one line between the title and body text.
+
+5. All sentences must start with lower case. Use capital letters only for proper nouns.
+
+6. Surround keywords with \`\`.
+
+7. Do not add your signature.
+
+8. If the reason for the changes is not clear from looking at the source,
+   please ask questions before creating the commit message and include the answers in your considerations.
+
+**IMPORTANT: Commit messages must be in English, but your reply must be in Japanese.**

--- a/configs/jj/config.toml
+++ b/configs/jj/config.toml
@@ -1,0 +1,19 @@
+#:schema https://docs.jj-vcs.dev/latest/config-schema.json
+
+[user]
+name = "yanosea"
+email = "81510859+yanosea@users.noreply.github.com"
+
+[ui]
+default-command = "log"
+pager = "delta"
+diff.tool = ["delta", "--color-only"]
+color = "auto"
+
+[git]
+colocate = true
+
+[signing]
+backend = "gpg"
+key = "B8C069E2833A7A32"
+sign-all = true

--- a/configs/starship/starship.toml
+++ b/configs/starship/starship.toml
@@ -3,22 +3,21 @@ format = """
 $os\
 [](bg:#a7c080 fg:#83c092)\
 $directory\
-[](fg:#a7c080 bg:#2d353b)\
-$git_branch\
-$git_status\
-[](fg:#2d353b bg:#343f44)\
+[](fg:#a7c080 bg:#2E383C)\
+${custom.jj}\
+[](fg:#2E383C bg:#374145)\
 $nodejs\
 $rust\
 $golang\
 $php\
-[](fg:#343f44 bg:#2d353b)\
+[](fg:#374145 bg:#2E383C)\
 $time\
-[ ](fg:#2d353b)\
+[ ](fg:#2E383C)\
 \n$character"""
 
 [os]
 format = "[ $symbol ]($style)"
-style = "bg:#83c092 fg:#090c0c"
+style = "bg:#83c092 fg:#272E33"
 disabled = false
 
 [os.symbols]
@@ -28,7 +27,7 @@ Macos = ""
 NixOS = ""
 
 [directory]
-style = "fg:#55544a bg:#a7c080"
+style = "fg:#7A8478 bg:#a7c080"
 format = "[ $path ]($style)"
 truncation_length = 3
 truncation_symbol = "…/"
@@ -40,36 +39,39 @@ truncation_symbol = "…/"
 "Pictures" = " "
 
 [git_branch]
-symbol = ""
-style = "bg:#2d353b"
-format = '[[ $symbol $branch ](fg:#a7c080 bg:#2d353b)]($style)'
+disabled = true
 
 [git_status]
-style = "bg:#2d353b"
-format = '[[($all_status$ahead_behind )](fg:#a7c080 bg:#2d353b)]($style)'
+disabled = true
 
 [nodejs]
 symbol = ""
-style = "bg:#343f44"
-format = '[[ $symbol ($version) ](fg:#a7c080 bg:#343f44)]($style)'
+style = "bg:#374145"
+format = '[[ $symbol ($version) ](fg:#a7c080 bg:#374145)]($style)'
 
 [rust]
 symbol = ""
-style = "bg:#343f44"
-format = '[[ $symbol ($version) ](fg:#a7c080 bg:#343f44)]($style)'
+style = "bg:#374145"
+format = '[[ $symbol ($version) ](fg:#a7c080 bg:#374145)]($style)'
 
 [golang]
 symbol = ""
-style = "bg:#343f44"
-format = '[[ $symbol ($version) ](fg:#a7c080 bg:#343f44)]($style)'
+style = "bg:#374145"
+format = '[[ $symbol ($version) ](fg:#a7c080 bg:#374145)]($style)'
 
 [php]
 symbol = ""
-style = "bg:#343f44"
-format = '[[ $symbol ($version) ](fg:#a7c080 bg:#343f44)]($style)'
+style = "bg:#374145"
+format = '[[ $symbol ($version) ](fg:#a7c080 bg:#374145)]($style)'
 
 [time]
 disabled = false
 time_format = "%H:%M:%S"
-style = "bg:#2d353b"
-format = '[[   $time ](fg:#d3c6aa bg:#2d353b)]($style)'
+style = "bg:#2E383C"
+format = '[[   $time ](fg:#d3c6aa bg:#2E383C)]($style)'
+
+[custom.jj]
+when = "jj-starship detect"
+shell = ["jj-starship"]
+style = "bg:#2E383C"
+format = '[[ $output ](fg:#a7c080 bg:#2E383C)]($style)'

--- a/configs/zsh/rc/abbreviations.zsh
+++ b/configs/zsh/rc/abbreviations.zsh
@@ -43,6 +43,9 @@ abbrev-alias grf='cd $(ghq list -p | fzf)'
 abbrev-alias ggl="git log --graph --all --oneline --decorate"
 ## lazy git
 abbrev-alias lg="lazygit"
+### lazy jj
+abbrev-alias lj="lazyjj"
+
 ## editor
 abbrev-alias nvimdiff="nvim -d"
 

--- a/flake.lock
+++ b/flake.lock
@@ -118,6 +118,24 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "gitlogue": {
       "inputs": {
         "nixpkgs": [
@@ -158,6 +176,28 @@
         "owner": "nix-community",
         "ref": "master",
         "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "jj-starship": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768065230,
+        "narHash": "sha256-FCkDSxGJAge86r5xMzr2lV0pjslS8ZQ7vBNId0VDDi0=",
+        "owner": "dmmulroy",
+        "repo": "jj-starship",
+        "rev": "0fe6d62a83b6964f33cff2658b39a7563e42dd09",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dmmulroy",
+        "ref": "main",
+        "repo": "jj-starship",
         "type": "github"
       }
     },
@@ -254,6 +294,7 @@
         "fenix": "fenix",
         "gitlogue": "gitlogue",
         "home-manager": "home-manager",
+        "jj-starship": "jj-starship",
         "nixos-hardware": "nixos-hardware",
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_3",
@@ -319,6 +360,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,15 @@
         };
       };
     };
+    ## jj-starship
+    jj-starship = {
+      url = "github:dmmulroy/jj-starship/main";
+      inputs = {
+        nixpkgs = {
+          follows = "nixpkgs";
+        };
+      };
+    };
     ## treefmt-nix
     treefmt-nix = {
       url = "github:numtide/treefmt-nix/main";

--- a/outputs/home-manager/shared-modules/cli/git.nix
+++ b/outputs/home-manager/shared-modules/cli/git.nix
@@ -37,7 +37,10 @@ in
           git-lfs
           github-cli
           gitlogue
+          jj-starship
+          jujutsu
           lazygit
+          lazyjj
         ];
       };
     }

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -105,6 +105,10 @@ inputs: [
       };
     }
   )
+  ## jj-starship
+  (final: prev: {
+    jj-starship = inputs.jj-starship.packages.${prev.stdenv.hostPlatform.system}.default;
+  })
   ## wrangler
   (final: prev: {
     wrangler = inputs.wrangler.packages.${prev.stdenv.hostPlatform.system}.wrangler;


### PR DESCRIPTION
- add `jujutsu`, `lazyjj`, and `jj-starship` packages to home-manager
- add `configs/jj/config.toml` with user, ui, git, and signing settings
- add `configs/claude/commands/csj.md` for jj commit workflow
- update `starship.toml` to use `jj-starship` and fix to Everforest official colors
- add `lj` abbreviation for `lazyjj` in zsh
- fix `overlays/default.nix` alphabetical order
                                                                                    
closes #1124