### PR TITLE
✨feat:(jj) add jujutsu integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,12 +163,16 @@ ifeq ($(IS_NIXOS),1)
 	rm -fr $$HOME/.config/fcitx5/config
 	nix run .#homeConfigurations."yanosea@yanoNixOs".activationPackage
 	@echo "$(COLOR_DONE)apply home configuration done!$(COLOR_RESET)"
+	@echo ""
+	@echo "$(COLOR_HEADER)hint: run 'reload' or 'exec zsh' to apply shell changes$(COLOR_RESET)"
 else ifeq ($(IS_NIXOS_WSL),1)
 	@echo "$(COLOR_TITLE)apply home configuration...$(COLOR_RESET)"
 	@echo ""
 	rm -fr $$HOME/.config/claude/CLAUDE.md
 	nix run .#homeConfigurations."yanosea@yanoNixOsWsl".activationPackage
 	@echo "$(COLOR_DONE)apply home configuration done!$(COLOR_RESET)"
+	@echo ""
+	@echo "$(COLOR_HEADER)hint: run 'reload' or 'exec zsh' to apply shell changes$(COLOR_RESET)"
 else ifeq ($(IS_MAC),1)
 	@echo "$(COLOR_TITLE)apply home configuration...$(COLOR_RESET)"
 	@echo ""
@@ -178,6 +182,8 @@ else ifeq ($(IS_MAC),1)
 	rm -fr $$HOME/.config/karabiner/karabiner.json
 	nix run .#homeConfigurations."yanosea@yanoMac".activationPackage
 	@echo "$(COLOR_DONE)apply home configuration done!$(COLOR_RESET)"
+	@echo ""
+	@echo "$(COLOR_HEADER)hint: run 'reload' or 'exec zsh' to apply shell changes$(COLOR_RESET)"
 else ifeq ($(IS_MACBOOK),1)
 	@echo "$(COLOR_TITLE)apply home configuration...$(COLOR_RESET)"
 	@echo ""
@@ -187,6 +193,8 @@ else ifeq ($(IS_MACBOOK),1)
 	rm -fr $$HOME/.config/karabiner/karabiner.json
 	nix run .#homeConfigurations."yanosea@yanoMacBook".activationPackage
 	@echo "$(COLOR_DONE)apply home configuration done!$(COLOR_RESET)"
+	@echo ""
+	@echo "$(COLOR_HEADER)hint: run 'reload' or 'exec zsh' to apply shell changes$(COLOR_RESET)"
 else
 	@echo "$(COLOR_ERROR)unsupported platform...$(COLOR_RESET)"
 endif
@@ -207,6 +215,8 @@ ifeq ($(IS_NIXOS),1)
 	@echo "$(COLOR_DONE)apply home configuration experimentally done!$(COLOR_RESET)"
 	@echo ""
 	@echo "$(COLOR_DONE)experimental update done!$(COLOR_RESET)"
+	@echo ""
+	@echo "$(COLOR_HEADER)hint: run 'reload' or 'exec zsh' to apply shell changes$(COLOR_RESET)"
 else ifeq ($(IS_NIXOS_WSL),1)
 	@echo "$(COLOR_TITLE)update nixos wsl experimentally...$(COLOR_RESET)"
 	@echo ""
@@ -220,6 +230,8 @@ else ifeq ($(IS_NIXOS_WSL),1)
 	@echo "$(COLOR_DONE)apply home configuration experimentally done!$(COLOR_RESET)"
 	@echo ""
 	@echo "$(COLOR_DONE)experimental update done!$(COLOR_RESET)"
+	@echo ""
+	@echo "$(COLOR_HEADER)hint: run 'reload' or 'exec zsh' to apply shell changes$(COLOR_RESET)"
 else ifeq ($(IS_MAC),1)
 	@echo "$(COLOR_TITLE)update mac experimentally...$(COLOR_RESET)"
 	@echo ""
@@ -236,6 +248,8 @@ else ifeq ($(IS_MAC),1)
 	@echo "$(COLOR_DONE)apply home configuration experimentally done!$(COLOR_RESET)"
 	@echo ""
 	@echo "$(COLOR_DONE)experimental update done!$(COLOR_RESET)"
+	@echo ""
+	@echo "$(COLOR_HEADER)hint: run 'reload' or 'exec zsh' to apply shell changes$(COLOR_RESET)"
 else ifeq ($(IS_MACBOOK),1)
 	@echo "$(COLOR_TITLE)update macbook experimentally...$(COLOR_RESET)"
 	@echo ""
@@ -252,6 +266,8 @@ else ifeq ($(IS_MACBOOK),1)
 	@echo "$(COLOR_DONE)apply home configuration experimentally done!$(COLOR_RESET)"
 	@echo ""
 	@echo "$(COLOR_DONE)experimental update done!$(COLOR_RESET)"
+	@echo ""
+	@echo "$(COLOR_HEADER)hint: run 'reload' or 'exec zsh' to apply shell changes$(COLOR_RESET)"
 else
 	@echo "$(COLOR_ERROR)unsupported platform...$(COLOR_RESET)"
 endif

--- a/configs/gemini/commands/csj.toml
+++ b/configs/gemini/commands/csj.toml
@@ -1,0 +1,58 @@
+# Commit command for jj (Jujutsu)
+
+prompt = """
+Please generate a commit message in English for the current working copy changes.
+- Show the following commands for the user to run manually in order:
+  1. `gh issue create` command:
+     - title format: `(scope) description` (e.g., `(ai) expand workflow`)
+     - no body
+     - label: `bug` for `fix:` prefix, `enhancement` for others
+     - assignee: self (`@me`)
+  2. `jj describe` command with the generated message
+  3. `jj bookmark create` command to create a bookmark for the issue (e.g., `123-feature-name`)
+  4. `nix fmt` command to format files
+  5. `jj git push` command to push the changes to remote with `-b <bookmark> --allow-new`
+  6. `gh pr create` command:
+     - body: commit message body + `closes #<issue-number>` (use `--body "$(jj log -r @- --no-graph -T description | tail -n +3)\n\ncloses #<issue-number>"`)
+     - label: same as issue
+     - assignee: same as issue (`@me`)
+  7. `gh pr merge` command to merge the pull request
+- Do not show the commit message separately; only show it in the commands.
+- Do not execute any commands, only show them for the user to run manually.
+
+## Rules
+
+1. The title should be at most 50 characters, and the body should be wrapped at 72 characters.
+   For the title, use one of the following prefixes, separated from the title by a space:
+
+   - `✨feat:` - Use for new feature additions
+   - `🐞fix:` - Use for bug fixes
+   - `📚docs:` - Use for documentation-only changes
+   - `💄style:` - Use for changes that do not affect program behavior (indentation adjustments, formatting, etc.)
+   - `🔧refactor:` - Use for code modifications other than bug fixes or feature additions
+   - `🚀perf:` - Use for code modifications aimed at performance improvements
+   - `🧪test:` - Use for adding tests or modifying existing tests
+   - `🧹chore:` - Use for changes to build process, auxiliary tools, or libraries
+   - `🔀merge:` - Use for merge commits
+
+2. Add () after prefix and fill it with the changed tool.
+   For example, if GitHub Workflow file was changed: (workflow)
+   If jj config file was changed: (jj)
+
+3. In the body, list the changes as bullet points, each starting with "- ".
+
+4. Leave one line between the title and body text.
+
+5. All sentences must start with lower case. Use capital letters only for proper nouns.
+
+6. Surround keywords with ` `.
+
+7. Do not add your signature.
+
+8. If the reason for the changes is not clear from looking at the source,
+   please ask questions before creating the commit message and include the answers in your considerations.
+
+!{jj diff}
+
+**IMPORTANT: Commit messages must be in English, but your reply must be in Japanese.**
+"""

--- a/configs/jj/config.toml
+++ b/configs/jj/config.toml
@@ -14,6 +14,6 @@ color = "auto"
 colocate = true
 
 [signing]
+behavior = "own"
 backend = "gpg"
 key = "B8C069E2833A7A32"
-sign-all = true

--- a/configs/nvim/lua/plugins/tools/internal/jj_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/internal/jj_nvim.lua
@@ -1,0 +1,38 @@
+-- jujutsu (jj) integration
+-- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>j)
+return {
+	{
+		"NicolasGB/jj.nvim",
+		lazy = true,
+		event = { "BufReadPost", "BufNewFile" },
+		config = function()
+			local colors = require("utils.colors").colors
+			require("jj").setup({
+				-- highlights
+				highlights = {
+					-- editor
+					added = { fg = colors.Green },
+					modified = { fg = colors.Blue },
+					deleted = { fg = colors.Red },
+					renamed = { fg = colors.Yellow },
+					-- log buffer
+					selected = { bg = colors.Bg },
+					targeted = { fg = colors.Green, bold = true },
+				},
+				-- describe editor
+				describe = {
+					editor = {
+						type = "buffer",
+						keymaps = {
+							close = { "q", "<Esc>" },
+						},
+					},
+				},
+				-- log
+				log = {
+					close_on_edit = true,
+				},
+			})
+		end,
+	},
+}

--- a/configs/nvim/lua/plugins/tools/internal/telescope.lua
+++ b/configs/nvim/lua/plugins/tools/internal/telescope.lua
@@ -14,6 +14,7 @@ return {
 				{ "2kabhishek/nerdy.nvim", dependencies = { "folke/snacks.nvim" } },
 				"nvim-telescope/telescope-ui-select.nvim",
 				"debugloop/telescope-undo.nvim",
+				"zschreur/telescope-jj.nvim",
 			},
 		},
 		lazy = true,
@@ -117,6 +118,7 @@ return {
 			-- load extensions
 			require("telescope").load_extension("file_browser")
 			require("telescope").load_extension("fzf")
+			require("telescope").load_extension("jj")
 			require("telescope").load_extension("nerdy")
 			require("telescope").load_extension("ui-select")
 			require("telescope").load_extension("undo")

--- a/configs/nvim/lua/plugins/tools/internal/toggleterm_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/internal/toggleterm_nvim.lua
@@ -1,5 +1,55 @@
 -- terminal in neovim
 -- keymaps are set in lua/plugins/tools/internal/which_key_nvim.lua (<LEADER>t)
+
+-- global toggle functions (defined outside config so they're available before plugin loads)
+function ToggleLazyGit()
+	require("lazy").load({ plugins = { "toggleterm.nvim" } })
+	vim.defer_fn(function()
+		local Terminal = require("toggleterm.terminal").Terminal
+		local lazygit = Terminal:new({
+			cmd = "lazygit",
+			hidden = true,
+			direction = "float",
+			float_opts = {
+				border = "none",
+				width = 100000,
+				height = 100000,
+				zindex = 200,
+			},
+			on_open = function(_)
+				vim.cmd("startinsert!")
+			end,
+			on_close = function(_) end,
+			count = 99,
+		})
+		lazygit:toggle()
+	end, 0)
+end
+
+function ToggleJjui()
+	require("lazy").load({ plugins = { "toggleterm.nvim" } })
+	vim.defer_fn(function()
+		local Terminal = require("toggleterm.terminal").Terminal
+		local jjui = Terminal:new({
+			cmd = "jjui",
+			hidden = true,
+			direction = "float",
+			float_opts = {
+				border = "none",
+				width = 100000,
+				height = 100000,
+				zindex = 200,
+			},
+			on_open = function(_)
+				vim.cmd("startinsert!")
+			end,
+			on_close = function(_) end,
+			count = 98,
+		})
+		jjui:toggle()
+	end, 0)
+end
+
 return {
 	{
 		"akinsho/toggleterm.nvim",
@@ -13,40 +63,10 @@ return {
 			"ToggleTermSendVisualSelection",
 		},
 		keys = {
-			{
-				"<LEADER>gg",
-				function()
-					local Terminal = require("toggleterm.terminal").Terminal
-					local lazygit = Terminal:new({
-						cmd = "lazygit",
-						hidden = true,
-						direction = "float",
-						float_opts = {
-							border = "none",
-							width = 100000,
-							height = 100000,
-							zindex = 200,
-						},
-						on_open = function(_)
-							vim.cmd("startinsert!")
-						end,
-						on_close = function(_) end,
-						count = 99,
-					})
-					lazygit:toggle()
-				end,
-				desc = "git: lazygit",
-			},
-			{
-				"<LEADER>ts",
-				"<CMD>ToggleTerm direction=horizontal<CR>",
-				desc = "terminal: horizontal",
-			},
-			{
-				"<LEADER>tv",
-				"<CMD>ToggleTerm direction=vertical<CR>",
-				desc = "terminal: vertical",
-			},
+			{ "<LEADER>gg", "<CMD>lua ToggleLazyGit()<CR>", desc = "git: lazygit" },
+			{ "<LEADER>jj", "<CMD>lua ToggleJjui()<CR>", desc = "jj: jjui" },
+			{ "<LEADER>ts", "<CMD>ToggleTerm direction=horizontal<CR>", desc = "terminal: horizontal" },
+			{ "<LEADER>tv", "<CMD>ToggleTerm direction=vertical<CR>", desc = "terminal: vertical" },
 		},
 		config = function()
 			-- toggleterm.nvim config

--- a/configs/nvim/lua/plugins/tools/internal/which_key_nvim.lua
+++ b/configs/nvim/lua/plugins/tools/internal/which_key_nvim.lua
@@ -130,6 +130,26 @@ return {
 					{ "<LEADER>gU", "<CMD>OpenGitHubUrlUnderCursor<CR>", desc = "git: open github url" },
 					-- grug far
 					{ "<LEADER>G", "<CMD>GrugFar<CR>", desc = "grug far: search and replace text" },
+					-- jj (jujutsu)
+					{ "<LEADER>j", group = "jj" },
+					{ "<LEADER>ja", "<CMD>lua require('jj.annotate').file()<CR>", desc = "jj: annotate file" },
+					{ "<LEADER>jA", "<CMD>lua require('jj.annotate').line()<CR>", desc = "jj: annotate line" },
+					{
+						"<LEADER>jc",
+						"<CMD>lua require('telescope').extensions.jj.conflicts()<CR>",
+						desc = "jj: conflict files",
+					},
+					{ "<LEADER>jd", "<CMD>J describe<CR>", desc = "jj: describe" },
+					{ "<LEADER>jD", "<CMD>lua require('telescope').extensions.jj.diff()<CR>", desc = "jj: diff files" },
+					{ "<LEADER>jf", "<CMD>lua require('telescope').extensions.jj.files()<CR>", desc = "jj: files" },
+					{ "<LEADER>je", "<CMD>J edit<CR>", desc = "jj: edit" },
+					{ "<LEADER>jF", "<CMD>J fetch<CR>", desc = "jj: fetch" },
+					{ "<LEADER>jj", "<CMD>lua ToggleJjui()<CR>", desc = "jj: jjui" },
+					{ "<LEADER>jl", "<CMD>J log<CR>", desc = "jj: log" },
+					{ "<LEADER>jn", "<CMD>J new<CR>", desc = "jj: new" },
+					{ "<LEADER>jo", "<CMD>J open_pr<CR>", desc = "jj: open pr" },
+					{ "<LEADER>jp", "<CMD>J push<CR>", desc = "jj: push" },
+					{ "<LEADER>js", "<CMD>J status<CR>", desc = "jj: status" },
 					-- hardtime
 					{ "<LEADER>H", "<CMD>Hardtime toggle<CR>", desc = "hardtime: toggle" },
 					-- lsp

--- a/configs/nvim/lua/plugins/ui/components/alpha_nvim.lua
+++ b/configs/nvim/lua/plugins/ui/components/alpha_nvim.lua
@@ -95,6 +95,7 @@ return {
 					"<CMD>Telescope file_browser cwd=" .. vim.fn.expand("%:p:h") .. "<CR>"
 				),
 				dashboard.button("g", icons.git.Git .. "  lazygit", "<CMD>lua ToggleLazyGit()<CR>"),
+				dashboard.button("j", icons.git.Branch .. "  jjui", "<CMD>lua ToggleJjui()<CR>"),
 				dashboard.button("l", icons.misc.Lazy .. "  lazy", "<CMD>Lazy<CR>"),
 				dashboard.button("m", icons.misc.Mason .. "  mason lsp", "<CMD>Mason<CR>"),
 				dashboard.button("T", icons.ui.Tree .. "  sync tree-sitter parser", "<CMD>TSUpdate<CR>"),

--- a/configs/starship/starship.toml
+++ b/configs/starship/starship.toml
@@ -3,21 +3,21 @@ format = """
 $os\
 [](bg:#a7c080 fg:#83c092)\
 $directory\
-[](fg:#a7c080 bg:#2E383C)\
-${custom.jj}\
-[](fg:#2E383C bg:#374145)\
+[](fg:#a7c080 bg:#343f44)\
 $nodejs\
 $rust\
 $golang\
 $php\
-[](fg:#374145 bg:#2E383C)\
+${custom.nix}\
+[](fg:#343f44 bg:#2d353b)\
+${custom.jj}\
+${custom.git}\
 $time\
-[ ](fg:#2E383C)\
 \n$character"""
 
 [os]
 format = "[ $symbol ]($style)"
-style = "bg:#83c092 fg:#272E33"
+style = "bg:#83c092 fg:#2d353b"
 disabled = false
 
 [os.symbols]
@@ -27,7 +27,7 @@ Macos = ""
 NixOS = ""
 
 [directory]
-style = "fg:#7A8478 bg:#a7c080"
+style = "fg:#2d353b bg:#a7c080"
 format = "[ $path ]($style)"
 truncation_length = 3
 truncation_symbol = "…/"
@@ -46,32 +46,44 @@ disabled = true
 
 [nodejs]
 symbol = ""
-style = "bg:#374145"
-format = '[[ $symbol ($version) ](fg:#a7c080 bg:#374145)]($style)'
+style = "bg:#343f44"
+format = '[[ $symbol ($version) ](fg:#a7c080 bg:#343f44)]($style)'
 
 [rust]
 symbol = ""
-style = "bg:#374145"
-format = '[[ $symbol ($version) ](fg:#a7c080 bg:#374145)]($style)'
+style = "bg:#343f44"
+format = '[[ $symbol ($version) ](fg:#a7c080 bg:#343f44)]($style)'
 
 [golang]
 symbol = ""
-style = "bg:#374145"
-format = '[[ $symbol ($version) ](fg:#a7c080 bg:#374145)]($style)'
+style = "bg:#343f44"
+format = '[[ $symbol ($version) ](fg:#a7c080 bg:#343f44)]($style)'
 
 [php]
 symbol = ""
-style = "bg:#374145"
-format = '[[ $symbol ($version) ](fg:#a7c080 bg:#374145)]($style)'
+style = "bg:#343f44"
+format = '[[ $symbol ($version) ](fg:#a7c080 bg:#343f44)]($style)'
 
 [time]
 disabled = false
 time_format = "%H:%M:%S"
-style = "bg:#2E383C"
-format = '[[   $time ](fg:#d3c6aa bg:#2E383C)]($style)'
+style = "bg:#2d353b"
+format = '[[   $time ](fg:#d3c6aa bg:#2d353b)]($style)'
 
 [custom.jj]
-when = "jj-starship detect"
-shell = ["jj-starship"]
-style = "bg:#2E383C"
-format = '[[ $output ](fg:#a7c080 bg:#2E383C)]($style)'
+when = "jj root 2>/dev/null"
+command = "jj-starship"
+style = "bg:#2d353b"
+format = '[ $output ](fg:#a7c080 bg:#2d353b)'
+
+[custom.git]
+when = "! jj root 2>/dev/null && git rev-parse --is-inside-work-tree 2>/dev/null"
+command = "echo \" $(git branch --show-current)$(git diff --quiet || echo ' !')$(git diff --cached --quiet || echo ' +')\" "
+style = "bg:#2d353b"
+format = '[[$output](fg:#a7c080 bg:#2d353b)]($style)'
+
+[custom.nix]
+when = "test -f flake.nix"
+command = "echo \"  $(jq -r '.nodes.nixpkgs.locked.rev' flake.lock 2>/dev/null | head -c 7)\""
+style = "bg:#343f44"
+format = '[[ $output ](fg:#a7c080 bg:#343f44)]($style)'

--- a/configs/zsh/rc/abbreviations.zsh
+++ b/configs/zsh/rc/abbreviations.zsh
@@ -41,9 +41,13 @@ abbrev-alias gbf='git switch $(git branch -l | fzf | tr -d "* ")'
 abbrev-alias grf='cd $(ghq list -p | fzf)'
 ### git graph log
 abbrev-alias ggl="git log --graph --all --oneline --decorate"
-## lazy git
+### jj bookmark fzf
+abbrev-alias jbf='jj new $(jj bookmark list | fzf | awk "{print \$1}")'
+### jjui
+abbrev-alias ju="jjui"
+### lazygit
 abbrev-alias lg="lazygit"
-### lazy jj
+### lazyjj
 abbrev-alias lj="lazyjj"
 
 ## editor
@@ -70,6 +74,10 @@ abbrev-alias ccusage="bunx ccusage@latest"
 abbrev-alias rtty='rtty run zellij --font "PlemolJP Console NF"'
 ## trello
 abbrev-alias trello="trello-tui -board yanoBoard"
+
+# shell
+## reload zsh
+abbrev-alias reload="exec zsh"
 
 # utilities
 ## nix-latest

--- a/outputs/apps/default.nix
+++ b/outputs/apps/default.nix
@@ -123,6 +123,8 @@ let
     ${mkHomeCommand host experimental}
     ${echo.done "apply home configuration${if experimental then " experimentally" else ""} done!"}
     ${echo.blank}
+    ${echo.header "hint: run 'reload' or 'exec zsh' to apply shell changes"}
+    ${echo.blank}
     ${
       if experimental then
         ""
@@ -160,6 +162,8 @@ let
       ${echo.blank}
       ${mkHomeCommand host false}
       ${echo.done "apply home configuration done!"}
+      ${echo.blank}
+      ${echo.header "hint: run 'reload' or 'exec zsh' to apply shell changes"}
     '';
     update = mkUpdateScript host false hostname;
     experiment = mkUpdateScript host true hostname;

--- a/outputs/home-manager/shared-modules/cli/default.nix
+++ b/outputs/home-manager/shared-modules/cli/default.nix
@@ -6,13 +6,13 @@
     ./development.nix
     ./docker.nix
     ./editor.nix
-    ./git.nix
     ./jookey.nix
     ./media.nix
     ./shell.nix
     ./secrets.nix
     ./symlinks.nix
     ./tools.nix
+    ./vcs.nix
     ./web.nix
     ./xdg.nix
   ];


### PR DESCRIPTION
- add `jj` config with `git.auto-local-bookmark` and aliases in `vcs.nix`
- rename `git.nix` to `vcs.nix` to consolidate version control settings
- add `jj-starship` custom module to detect jj repository in starship
- add `custom.git` module to show git status only in non-jj repositories
- add `custom.nix` module to detect `flake.nix` and show nixpkgs revision
- add `jj.nvim` plugin with highlights and editor configuration
- add `telescope-jj.nvim` extension for jj file/diff/conflict pickers
- add 14 jj keymaps under `<LEADER>j` in which-key
- fix `ToggleLazyGit` and `ToggleJjui` lazy loading in toggleterm
- add jj-related zsh abbreviations
- add `csj.toml` gemini command for jj commit workflow
- add jj targets to Makefile
- add `jjui` dashboard shortcut in alpha-nvim

closes #1128