### PR TITLE
✨feat:(terminal) add `ghostty` terminal emulator

### DIFF
--- a/configs/ghostty/config
+++ b/configs/ghostty/config
@@ -1,0 +1,79 @@
+# ghostty config
+# Using with zellij for tab/pane management
+
+# Platform-specific config (optional, ignored if not exists)
+config-file = ?platform/linux
+config-file = ?platform/macos
+
+# Theme
+theme = everforest-dark
+
+# Font
+font-family = PlemolJP Console NF
+font-style = Medium
+
+# Window
+window-padding-x = 0
+window-padding-y = 0
+window-decoration = none
+background-opacity = 0.8
+
+# Cursor
+cursor-style = block
+cursor-style-blink = true
+
+# Shell integration
+shell-integration = detect
+
+# Scrollback
+scrollback-limit = 3500
+
+# Clipboard
+clipboard-read = allow
+clipboard-write = allow
+clipboard-paste-protection = false
+
+# Quick terminal (for btop etc.)
+quick-terminal-position = center
+
+# Keybindings
+keybind = ctrl+shift+c=copy_to_clipboard
+keybind = ctrl+shift+v=paste_from_clipboard
+
+# Tab
+keybind = ctrl+shift+t=new_tab
+keybind = ctrl+shift+w=close_surface
+keybind = ctrl+shift+k=previous_tab
+keybind = ctrl+shift+j=next_tab
+keybind = ctrl+shift+one=goto_tab:1
+keybind = ctrl+shift+two=goto_tab:2
+keybind = ctrl+shift+three=goto_tab:3
+keybind = ctrl+shift+four=goto_tab:4
+keybind = ctrl+shift+five=goto_tab:5
+keybind = ctrl+shift+six=goto_tab:6
+keybind = ctrl+shift+seven=goto_tab:7
+keybind = ctrl+shift+eight=goto_tab:8
+keybind = ctrl+shift+nine=goto_tab:9
+
+# Split
+keybind = ctrl+shift+enter=new_split:auto
+keybind = ctrl+shift+s=new_split:down
+keybind = ctrl+shift+d=new_split:right
+keybind = ctrl+shift+h=goto_split:left
+keybind = ctrl+shift+l=goto_split:right
+keybind = ctrl+shift+alt+k=goto_split:top
+keybind = ctrl+shift+alt+j=goto_split:bottom
+
+# Resize split
+keybind = ctrl+shift+left=resize_split:left,10
+keybind = ctrl+shift+right=resize_split:right,10
+keybind = ctrl+shift+up=resize_split:up,10
+keybind = ctrl+shift+down=resize_split:down,10
+
+# Font size
+keybind = ctrl+shift+u=increase_font_size:1
+keybind = ctrl+shift+m=decrease_font_size:1
+keybind = ctrl+shift+zero=reset_font_size
+
+# Misc
+confirm-close-surface = false

--- a/configs/ghostty/platform/linux
+++ b/configs/ghostty/platform/linux
@@ -1,0 +1,4 @@
+# Linux-specific ghostty config
+
+# Font size
+font-size = 10

--- a/configs/ghostty/platform/macos
+++ b/configs/ghostty/platform/macos
@@ -1,0 +1,7 @@
+# macOS-specific ghostty config
+
+# Font size
+font-size = 14
+
+# macOS options
+macos-option-as-alt = true

--- a/configs/ghostty/themes/everforest-dark
+++ b/configs/ghostty/themes/everforest-dark
@@ -1,0 +1,33 @@
+# Everforest Dark theme for Ghostty
+# Based on https://github.com/sainnhe/everforest
+
+# Background and foreground
+background = 2d353b
+foreground = d3c6aa
+
+# Cursor
+cursor-color = d3c6aa
+
+# Selection
+selection-background = 475258
+selection-foreground = d3c6aa
+
+# Normal colors
+palette = 0=#475258
+palette = 1=#e67e80
+palette = 2=#a7c080
+palette = 3=#dbbc7f
+palette = 4=#7fbbb3
+palette = 5=#d699b6
+palette = 6=#83c092
+palette = 7=#d3c6aa
+
+# Bright colors
+palette = 8=#414b50
+palette = 9=#e67e80
+palette = 10=#a7c080
+palette = 11=#dbbc7f
+palette = 12=#7fbbb3
+palette = 13=#d699b6
+palette = 14=#83c092
+palette = 15=#d3c6aa

--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -99,7 +99,7 @@ env = XDG_CURRENT_DESKTOP,Hyprland
 env = XDG_SESSION_TYPE,wayland
 env = XDG_SESSION_DESKTOP,Hyprland
 # windowrulev2
-## vim via wezterm for ime
+## vim via ghostty for ime
 windowrulev2 = float, class:FloatingVim
 ## mod the spire - force tiling
 windowrulev2 = tile, class:com-evacipated-cardcrawl-modthespire-Loader
@@ -164,8 +164,8 @@ bindm = $mainMod SHIFT, mouse:273, resizewindow
 ## shortcuts
 ### application launcher
 bind = $mainMod, Space, exec, qs ipc call launcher toggle
-### btop via wezterm (like taskmgr)
-bind = CTRL SHIFT, ESCAPE, exec, wezterm -e btop
+### btop via ghostty (like taskmgr)
+bind = CTRL SHIFT, ESCAPE, exec, ghostty -e btop
 ### clipboard history via quickshell launcher
 bind = CTRL SHIFT, Q, exec, qs ipc call launcher clipboard
 ### browser
@@ -175,7 +175,7 @@ bind = SUPER, E, exec, nemo
 ### kill active window
 bind = SUPER, Q, killactive
 ### terminal
-bind = SUPER, T, exec, wezterm
+bind = SUPER, T, exec, ghostty
 ### lock screen
 bind = SUPER, L, exec, qs ipc call lockScreen lock
 ### screenshot

--- a/configs/niri/config.kdl
+++ b/configs/niri/config.kdl
@@ -132,7 +132,7 @@ environment {
     XDG_SESSION_DESKTOP "niri"
 }
 // window rules
-//// vim via wezterm for ime
+//// vim via ghostty for ime
 window-rule {
     match app-id="FloatingVim"
     open-floating true
@@ -376,7 +376,7 @@ binds {
     }
     // application
     Super+T {
-        spawn "wezterm"
+        spawn "ghostty"
     }
     Super+B {
         spawn "vivaldi"
@@ -394,7 +394,7 @@ binds {
         spawn "qs" "ipc" "call" "launcher" "toggle"
     }
     Ctrl+Shift+Escape {
-        spawn "wezterm" "-e" "btop"
+        spawn "ghostty" "-e" "btop"
     }
     Ctrl+Shift+Q {
         spawn "qs" "ipc" "call" "launcher" "clipboard"

--- a/configs/quickshell/settings.json
+++ b/configs/quickshell/settings.json
@@ -7,7 +7,7 @@
     "pinnedExecs": [],
     "position": "center",
     "sortByMostUsed": true,
-    "terminalCommand": "wezterm start --",
+    "terminalCommand": "ghostty -e",
     "useApp2Unit": false
   },
   "audio": {

--- a/outputs/darwin/shared-modules/brew.nix
+++ b/outputs/darwin/shared-modules/brew.nix
@@ -27,6 +27,7 @@
       "easyfind"
       "font-sf-mono"
       "font-sf-pro"
+      "ghostty"
       "github@beta"
       "google-chrome"
       "google-drive"

--- a/outputs/home-manager/hosts/yanoNixOs/gui/terminal.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/terminal.nix
@@ -4,6 +4,7 @@
   # home
   home = {
     packages = with pkgs; [
+      ghostty
       wezterm
     ];
   };

--- a/outputs/nixos/yanoNixOs/desktop/xdg-mime.nix
+++ b/outputs/nixos/yanoNixOs/desktop/xdg-mime.nix
@@ -190,7 +190,7 @@
       BROWSER = "vivaldi";
       EDITOR = "nvim";
       VISUAL = "nvim";
-      TERMINAL = "wezterm";
+      TERMINAL = "ghostty";
       FILE_MANAGER = "nemo";
       PAGER = "less";
     };


### PR DESCRIPTION
- add `ghostty` config with everforest-dark theme
- add platform-specific configs for Linux and macOS
- replace `wezterm` with `ghostty` in `hyprland` and `niri`
- update `quickshell` terminal command to use `ghostty`
- add `ghostty` package to NixOS and darwin

closes #1133