### PR TITLE
🐞fix(treefmt): replace `mdformat` with `prettier` for markdown

### DIFF
--- a/configs/claude/commands/cs.md
+++ b/configs/claude/commands/cs.md
@@ -24,7 +24,6 @@
 
 1. The title should be at most 50 characters, and the body should be wrapped at 72 characters.
    For the title, use one of the following prefixes, separated from the title by a space:
-
    - `feat:` - Use for new feature additions
    - `fix:` - Use for bug fixes
    - `docs:` - Use for documentation-only changes

--- a/configs/claude/commands/csj.md
+++ b/configs/claude/commands/csj.md
@@ -3,7 +3,6 @@
 - Please generate a commit message in English for the current working copy changes.
 
 - Show the following commands for the user to run manually in order:
-
   1. `gh issue create` command:
      - title format: `(scope) description` (e.g., `(ai) expand workflow`)
      - no body
@@ -31,7 +30,6 @@
 
 1. The title should be at most 50 characters, and the body should be wrapped at 72 characters.
    For the title, use one of the following prefixes, separated from the title by a space:
-
    - `✨feat:` - Use for new feature additions
    - `🐞fix:` - Use for bug fixes
    - `📚docs:` - Use for documentation-only changes

--- a/outputs/formatter/default.nix
+++ b/outputs/formatter/default.nix
@@ -6,12 +6,13 @@ genAttrs [ "x86_64-linux" "aarch64-darwin" ] (
   (inputs.treefmt-nix.lib.evalModule inputs.nixpkgs.legacyPackages.${system} {
     projectRootFile = "flake.nix";
     programs = {
-      # css, html
+      # css, html, markdown
       prettier = {
         enable = true;
         includes = [
           "*.css"
           "*.html"
+          "*.md"
         ];
         excludes = [
           "configs/quickshell/Assets/MatugenTemplates/**"
@@ -30,14 +31,6 @@ genAttrs [ "x86_64-linux" "aarch64-darwin" ] (
       # lua
       stylua = {
         enable = true;
-      };
-      # markdown
-      mdformat = {
-        enable = true;
-        includes = [ "*.md" ];
-        settings = {
-          number = true;
-        };
       };
       # nix
       nixfmt = {


### PR DESCRIPTION
- replace `mdformat` with `prettier` for markdown formatting
- `mdformat` build fails due to `markdown-it-py` version conflict
- align with neovim's efm-langserver configuration
