### PR TITLE
🧹chore:(nix) remove `universalaccess` defaults from darwin config

### DIFF
--- a/outputs/darwin/shared-modules/defaults/ui.nix
+++ b/outputs/darwin/shared-modules/defaults/ui.nix
@@ -33,13 +33,6 @@
       spaces = {
         spans-displays = false;
       };
-      universalaccess = {
-        closeViewScrollWheelToggle = false;
-        closeViewZoomFollowsFocus = false;
-        mouseDriverCursorSize = 1.0;
-        reduceMotion = false;
-        reduceTransparency = false;
-      };
       WindowManager = {
         AppWindowGroupingBehavior = true;
         AutoHide = false;


### PR DESCRIPTION
- remove `system.defaults.universalaccess` block from `ui.nix`
- these settings were all default values and caused permission errors
- `com.apple.universalaccess` domain requires root privileges to write

closes #1150 
