### PR TITLE
🔧refactor:(hypr) migrate `windowrulev2` to new `windowrule` syntax

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -98,12 +98,12 @@ env = XMODIFIERS,@im=fcitx
 env = XDG_CURRENT_DESKTOP,Hyprland
 env = XDG_SESSION_TYPE,wayland
 env = XDG_SESSION_DESKTOP,Hyprland
-# windowrulev2
+# windowrule
 ## vim via wezterm for ime
-windowrulev2 = float, class:FloatingVim
+windowrule = float on, match:class ^(FloatingVim)$
 ## mod the spire - force tiling
-windowrulev2 = tile, class:com-evacipated-cardcrawl-modthespire-Loader
-windowrulev2 = tile, title:ModTheSpire
+windowrule = tile on, match:class ^(com-evacipated-cardcrawl-modthespire-Loader)$
+windowrule = tile on, match:title ^(ModTheSpire)$
 # bind
 ## mainmod
 $mainMod = ALT


### PR DESCRIPTION
- update `windowrulev2 = float, class:FloatingVim` to new `windowrule = float on, match:class ^(FloatingVim)$` syntax
- update `windowrulev2 = tile, class:...` rules for mod the spire to use new `windowrule = tile on, match:class/title` format
- follow hyprland 0.48+ breaking change where `windowrulev2` is deprecated

closes #1155