### PR TITLE
📚docs:(ai) clarify bookmark naming format for `csj` command

### DIFF
--- a/configs/claude/commands/csj.md
+++ b/configs/claude/commands/csj.md
@@ -10,17 +10,17 @@
      - assignee: self (`@me`)
   2. `nix fmt` command to format files
   3. `jj describe` command with the generated message
-  4. `jj bookmark create` command to create a bookmark for the issue (e.g., `123-feature-name`)
+  4. `jj bookmark create` command to create a bookmark matching `gh issue develop` default format:
+     - format: `<issue-number>-<issue-title-in-kebab-case>` (e.g., `1154-hypr-migrate-windowrulev2-to-new-windowrule-syntax`)
   5. `jj git push` command to push the changes to remote with `-b <bookmark> --allow-new`
   6. `gh pr create` command:
      - **IMPORTANT: use `--head <bookmark>` flag** (jj does not use git branches, so branch detection fails without this)
      - body: commit message body + `closes #<issue-number>`
      - label: same as issue
      - assignee: same as issue (`@me`)
-  7. `gh pr merge` command to merge the pull request:
-     - **IMPORTANT: specify PR number** (e.g., `gh pr merge <pr-number>`)
-  8. cleanup command:
-     - `jj git fetch && jj bookmark delete <bookmark>`
+  7. `gh pr merge <pr-number>` command to merge the pull request
+  8. cleanup commands:
+     - `jj git fetch && jj rebase -d main && jj bookmark delete <bookmark>`
 
 - Do not show the commit message separately; only show it in the commands.
 

--- a/configs/gemini/commands/csj.toml
+++ b/configs/gemini/commands/csj.toml
@@ -10,18 +10,18 @@ Please generate a commit message in English for the current working copy changes
      - assignee: self (`@me`)
   2. `nix fmt` command to format files
   3. `jj describe` command with the generated message
-  4. `jj bookmark create` command to create a bookmark for the issue (e.g., `123-feature-name`)
+  4. `jj bookmark create` command to create a bookmark matching `gh issue develop` default format:
+     - format: `<issue-number>-<issue-title-in-kebab-case>` (e.g., `1154-hypr-migrate-windowrulev2-to-new-windowrule-syntax`)
   5. `jj git push` command to push the changes to remote with `-b <bookmark> --allow-new`
   6. `gh pr create` command:
      - **IMPORTANT: use `--head <bookmark>` flag** (jj does not use git branches, so branch detection fails without this)
      - body: commit message body + `closes #<issue-number>`
      - label: same as issue
      - assignee: same as issue (`@me`)
-  7. `gh pr merge` command to merge the pull request:
-     - **IMPORTANT: specify PR number** (e.g., `gh pr merge <pr-number>`)
-  8. cleanup command:
-     - `jj git fetch && jj bookmark delete <bookmark>`
-- Do not show the commit message separately; only show them for the user to run manually.
+  7. `gh pr merge <pr-number>` command to merge the pull request
+  8. cleanup commands:
+     - `jj git fetch && jj rebase -d main && jj bookmark delete <bookmark>`
+- Do not show the commit message separately; only show it in the commands.
 - Do not execute any commands, only show them for the user to run manually.
 
 ## Rules


### PR DESCRIPTION
- update bookmark format description to match `gh issue develop` default
- add explicit format example: `<issue-number>-<issue-title-in-kebab-case>`
- sync `jj rebase -d main` step across claude and gemini configs
- unify wording between claude and gemini command files

closes #1157