### PR TITLE
🐞fix:(quickshell) fix FD leak in GPU monitoring processes

### DIFF
--- a/configs/quickshell/Services/SystemStatService.qml
+++ b/configs/quickshell/Services/SystemStatService.qml
@@ -411,10 +411,12 @@ Singleton {
 
   // --------------------------------------------
   // GPU monitoring using nvidia-smi
+  // Use onRunningChanged to restart after process exits to prevent FD leak
   Process {
     id: gpuUsageProcess
     command: ["nvidia-smi", "--query-gpu=utilization.gpu", "--format=csv,noheader,nounits"]
     running: true
+    onRunningChanged: if (!running) running = true
 
     stdout: SplitParser {
       onRead: data => {
@@ -430,6 +432,7 @@ Singleton {
     id: gpuTempProcess
     command: ["nvidia-smi", "--query-gpu=temperature.gpu", "--format=csv,noheader,nounits"]
     running: true
+    onRunningChanged: if (!running) running = true
 
     stdout: SplitParser {
       onRead: data => {
@@ -438,18 +441,6 @@ Singleton {
           root.gpuTemp = temp
         }
       }
-    }
-  }
-
-  Timer {
-    interval: root.sleepDuration
-    running: true
-    repeat: true
-    onTriggered: {
-      gpuUsageProcess.running = false
-      gpuTempProcess.running = false
-      gpuUsageProcess.running = true
-      gpuTempProcess.running = true
     }
   }
 }


### PR DESCRIPTION
- add `onRunningChanged` handler to restart `Process` after exit
- remove redundant `Timer` that manually toggled `running` state
- prevents file descriptor accumulation from process polling

closes #1167