### PR TITLE
🐞fix:(overlay) fix deprecated xorg package names

### DIFF
--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -87,9 +87,9 @@ inputs: [
             python311Packages.pip
             python311Packages.virtualenv
             stdenv.cc.cc.lib
-            xorg.libX11
-            xorg.libXext
-            xorg.libXrender
+            libx11
+            libxext
+            libxrender
             zlib
           ]);
         profile = ''


### PR DESCRIPTION
- replace `xorg.libX11` with `libx11`
- replace `xorg.libXext` with `libxext`
- replace `xorg.libXrender` with `libxrender`

closes #1172