### PR TITLE
🐞fix:(hypr) fix quickshell reload keybind

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -206,7 +206,7 @@ bind = SUPER SHIFT, C, exec, hyprpicker -a -f hex
 #### reload hyprland config
 bind = SUPER SHIFT, H, exec, sh -c 'hyprctl reload && notify-send "Hyprland" "Configuration reloaded!"'
 #### reload quickshell config
-bind = SUPER SHIFT, B, exec, sh -c 'pkill quickshell; qs &; notify-send "QuickShell" "Configuration reloaded!"'
+bind = SUPER SHIFT, B, exec, sh -c 'pkill quickshell; qs & notify-send "QuickShell" "Configuration reloaded!"'
 ### system controls
 #### reboot
 bind = SUPER SHIFT, R, exec, qs ipc call sessionMenu reboot


### PR DESCRIPTION
- fix `&;` syntax error in `SUPER SHIFT B` bind
- `&` is already a command terminator in `sh`, so the trailing `;` caused the entire `sh -c` command to fail silently

closes #1180