### PR TITLE
🧹chore:(claude/gemini) update `cs` and `csj`

### DIFF
--- a/configs/claude/commands/cs.md
+++ b/configs/claude/commands/cs.md
@@ -20,6 +20,15 @@
 - Do not execute any commands, only show them for the user to run manually.
 - Do not stage any files or lines.
 
+- Predict the issue number using `gh`:
+  - Get the latest number: `gh pr list --state all --limit 1 --json number --jq '.[0].number'`
+  - The next issue number = latest + 1
+  - Use the predicted number directly in all commands (no variables or placeholders)
+
+- Write all commands to `/tmp/commit-<issue-number>` as a plain text file for copy-paste (no shebang, no variables, no script logic)
+
+- At the end of your reply, show the output file path: `/tmp/commit-<issue-number>`
+
 ## Rules
 
 1. The title should be at most 50 characters, and the body should be wrapped at 72 characters.

--- a/configs/claude/commands/csj.md
+++ b/configs/claude/commands/csj.md
@@ -26,6 +26,15 @@
 
 - Do not execute any commands, only show them for the user to run manually.
 
+- Predict the issue number and PR number using `gh`:
+  - Get the latest number: `gh pr list --state all --limit 1 --json number --jq '.[0].number'`
+  - The next issue number = latest + 1, PR number = latest + 2
+  - Use the predicted numbers directly in all commands (no variables or placeholders)
+
+- Write all commands to `/tmp/commit-<issue-number>` as a plain text file for copy-paste (no shebang, no variables, no script logic)
+
+- At the end of your reply, show the output file path: `/tmp/commit-<issue-number>`
+
 ## Rules
 
 1. The title should be at most 50 characters, and the body should be wrapped at 72 characters.

--- a/configs/gemini/commands/cs.toml
+++ b/configs/gemini/commands/cs.toml
@@ -20,6 +20,12 @@ Please generate a commit message in English for these staged changes.
 - Do not show the commit message separately; only show it in the commands.
 - Do not execute any commands, only show them for the user to run manually.
 - Do not stage any files or lines.
+- Predict the issue number using `gh`:
+  - Get the latest number: `gh pr list --state all --limit 1 --json number --jq '.[0].number'`
+  - The next issue number = latest + 1
+  - Use the predicted number directly in all commands (no variables or placeholders)
+- Write all commands to `/tmp/commit-<issue-number>` as a plain text file for copy-paste (no shebang, no variables, no script logic)
+- At the end of your reply, show the output file path: `/tmp/commit-<issue-number>`
 
 ## Rules
 

--- a/configs/gemini/commands/csj.toml
+++ b/configs/gemini/commands/csj.toml
@@ -23,6 +23,12 @@ Please generate a commit message in English for the current working copy changes
      - `jj git fetch && jj rebase -d main && jj bookmark delete <bookmark>`
 - Do not show the commit message separately; only show it in the commands.
 - Do not execute any commands, only show them for the user to run manually.
+- Predict the issue number and PR number using `gh`:
+  - Get the latest number: `gh pr list --state all --limit 1 --json number --jq '.[0].number'`
+  - The next issue number = latest + 1, PR number = latest + 2
+  - Use the predicted numbers directly in all commands (no variables or placeholders)
+- Write all commands to `/tmp/commit-<issue-number>` as a plain text file for copy-paste (no shebang, no variables, no script logic)
+- At the end of your reply, show the output file path: `/tmp/commit-<issue-number>`
 
 ## Rules
 


### PR DESCRIPTION
- add issue/PR number prediction using `gh` CLI
- write commands to `/tmp/commit-<issue-number>` for copy-paste instead of inline display
- apply to both Claude and Gemini command files

closes #1195