### PR TITLE
🐞fix:(zsh) remove `zsh-you-should-use` plugin

### DIFF
--- a/configs/sheldon/plugins.toml
+++ b/configs/sheldon/plugins.toml
@@ -38,10 +38,6 @@ apply = ["fpath_comp", "defer"]
 github = "jimhester/per-directory-history"
 apply = ["defer"]
 
-[plugins.zsh-you-should-use]
-github = "MichaelAquilina/zsh-you-should-use"
-apply = ["defer"]
-
 [plugins.zoxide]
 inline = "zsh-defer eval \"$(zoxide init zsh)\""
 


### PR DESCRIPTION
- remove `zsh-you-should-use` from `sheldon` plugins
- the plugin conflicts with `zsh-abbrev-alias` by showing redundant alias suggestions when typing the expanded form of abbreviations

closes #1198