### PR TITLE
🔧refactor:(wezterm) remap font size keybinds

### DIFF
--- a/configs/wezterm/wezterm.lua
+++ b/configs/wezterm/wezterm.lua
@@ -236,8 +236,8 @@ return {
 		{ key = "?", mods = "LEADER|SHIFT|" .. ctrl_key, action = act.Search("CurrentSelectionOrEmptyString") },
 		{ key = "d", mods = "LEADER|SHIFT|" .. ctrl_key, action = act.ShowDebugOverlay },
 		-- key binding
-		{ key = "u", mods = "SHIFT|" .. ctrl_key, action = wezterm.action.IncreaseFontSize },
-		{ key = "m", mods = "SHIFT|" .. ctrl_key, action = wezterm.action.DecreaseFontSize },
+		{ key = "y", mods = "SHIFT|" .. ctrl_key, action = wezterm.action.IncreaseFontSize },
+		{ key = "n", mods = "SHIFT|" .. ctrl_key, action = wezterm.action.DecreaseFontSize },
 		{ key = "b", mods = "SHIFT|" .. ctrl_key, action = wezterm.action.EmitEvent("toggle-opacity") },
 	},
 	key_tables = {


### PR DESCRIPTION
- change `IncreaseFontSize` from `Ctrl+Shift+U` to `Ctrl+Shift+Y`
- change `DecreaseFontSize` from `Ctrl+Shift+M` to `Ctrl+Shift+N`
- avoid conflict with fcitx5 unicode input (`Ctrl+Shift+U`)
- keep right index finger up/down spatial layout

closes #1203