### PR TITLE
🔧refactor:(wine) replace deprecated package set

### DIFF
--- a/outputs/home-manager/hosts/yanoNixOs/cli/wine.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/cli/wine.nix
@@ -4,7 +4,7 @@
   # home
   home = {
     packages = with pkgs; [
-      wineWowPackages.staging
+      wineWow64Packages.staging
       winetricks
     ];
   };


### PR DESCRIPTION
- replace `wineWowPackages.staging` with `wineWow64Packages.staging`
- upstream now prefers `wineWow64Packages` over the deprecated `wineWowPackages`

closes #1205