### PR TITLE
(git) add ai tool patterns to global ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,21 +7,10 @@ configs/vim/plugged/
 configs/vim/undo
 configs/vim/viminfo
 configs/wakatime/
-specs/
-.claude/
-.gemini/
-.serena/
-.specify/
 # IGNORE FILE
 configs/gh/hosts.yml
 configs/github-copilot/apps.json
 configs/github-copilot/versions.json
 configs/lf/files
 configs/nvim/lazy-lock.json
-CLAUDE.md
-GEMINI.md
-HANDOVER.md
-HANDOVER.md.bak
 result
-.DS_Store
-*.log

--- a/configs/git/ignore
+++ b/configs/git/ignore
@@ -1,7 +1,15 @@
 # IGNORE DIRECTORY
-home/dotfiles/glzr/glzr/zebar/tmp*
+specs/
+.claude/
+.gemini/
+.serena/
+.specify/
 # IGNORE FILE
 desktop.ini
+CLAUDE.md
+GEMINI.md
+HANDOVER.md
+HANDOVER.md.bak
 .DS_Store
 .wakatime-project
 *.log


### PR DESCRIPTION
add ai tool patterns to global ignore

- globally ignore ai tool directories: `specs/`,
  `.claude/`, `.gemini/`, `.serena/`, `.specify/`
- globally ignore ai tool files: `CLAUDE.md`,
  `GEMINI.md`, `HANDOVER.md`, `HANDOVER.md.bak`
- remove obsolete `home/dotfiles/glzr/glzr/zebar/tmp*`
  entry

closes #1221