### PR TITLE
🔧refactor(vim): use native XDG support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@ configs/go/
 configs/scoop/
 configs/vim/autoload/
 configs/vim/plugged/
-configs/vim/undo
-configs/vim/viminfo
 configs/wakatime/
 # IGNORE FILE
 configs/gh/hosts.yml

--- a/Makefile
+++ b/Makefile
@@ -500,7 +500,7 @@ endif
 # 	@echo ""
 # 	@echo "$(COLOR_HEADER)install vimplug...$(COLOR_RESET)"
 # 	@echo ""
-# 	curl -fLo $$HOME/.vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+# 	curl -fLo $$XDG_CONFIG_HOME/vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 # 	@echo ""
 # 	@echo "$(COLOR_DONE)initialize done!$(COLOR_RESET)"
 # 	@echo ""
@@ -545,7 +545,7 @@ endif
 # 	@echo ""
 # 	@echo "$(COLOR_HEADER)install vimplug...$(COLOR_RESET)"
 # 	@echo ""
-# 	curl -fLo $$HOME/.vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+# 	curl -fLo $$XDG_CONFIG_HOME/vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 # 	@echo ""
 # 	@echo "$(COLOR_DONE)initialize done!$(COLOR_RESET)"
 # 	@echo ""
@@ -588,7 +588,7 @@ mac.init:
 # 	@echo ""
 # 	@echo "$(COLOR_HEADER)install vimplug...$(COLOR_RESET)"
 # 	@echo ""
-# 	curl -fLo $$HOME/.vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+# 	curl -fLo $$XDG_CONFIG_HOME/vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 # 	@echo ""
 # 	@echo "$(COLOR_DONE)initialize done!$(COLOR_RESET)"
 # 	@echo ""
@@ -631,7 +631,7 @@ mac.init:
 # 	@echo ""
 # 	@echo "$(COLOR_HEADER)install vimplug...$(COLOR_RESET)"
 # 	@echo ""
-# 	curl -fLo $$HOME/.vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
+# 	curl -fLo $$XDG_CONFIG_HOME/vim/autoload/plug.vim --create-dirs https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
 # 	@echo ""
 # 	@echo "$(COLOR_DONE)initialize done!$(COLOR_RESET)"
 # 	@echo ""

--- a/configs/vim/vimrc
+++ b/configs/vim/vimrc
@@ -60,15 +60,12 @@ set whichwrap-=l
 " display
 set display=lastline
 " persist undo
-let vim_dir = expand('$HOME/.vim')
-let undo_dir = vim_dir . '/undo'
+let undo_dir = expand('$XDG_STATE_HOME') . '/vim/undo'
 if !isdirectory(undo_dir)
 	call mkdir(undo_dir, 'p')
 endif
 set undofile
 exe 'set undodir=' .. undo_dir
-" viminfo
-set viminfo+=n$HOME/.vim/viminfo
 " standard plugin
 filetype plugin on
 let g:netrw_liststyle=1

--- a/outputs/home-manager/shared-modules/cli/symlinks.nix
+++ b/outputs/home-manager/shared-modules/cli/symlinks.nix
@@ -10,8 +10,6 @@
         # create symbolic links to scripts
         $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/installGitEmojiPrefixTemplate.sh $HOME/.local/bin/installGitEmojiPrefixTemplate
         $DRY_RUN_CMD ln -sf $HOME/ghq/github.com/yanosea/yanoNixFiles/ops/scripts/common/installNixFmtPreCommitHook.sh $HOME/.local/bin/installNixFmtPreCommitHook
-        # create vim configuration symlink
-        $DRY_RUN_CMD ln -sf $XDG_CONFIG_HOME/vim $HOME/.vim
       '';
     };
   };


### PR DESCRIPTION
- remove `$HOME/.vim` symlink workaround from `symlinks.nix`
- use `$XDG_STATE_HOME/vim/undo` for undo directory
- remove explicit `viminfo` path setting
- remove `configs/vim/undo` and `configs/vim/viminfo`
  from `.gitignore`

closes #1231