### PR TITLE
✨feat(wallpaper-engine): add local path support

### DIFF
--- a/ops/scripts/nixos/wallpaper-engine.sh
+++ b/ops/scripts/nixos/wallpaper-engine.sh
@@ -112,6 +112,7 @@ SUBCOMMANDS:
 
 Run without arguments to start random mode (rotates every 10 minutes).
 Use -i or --interactive for manual wallpaper selection.
+Specify a local path (with project.json) to launch a custom wallpaper.
 
 FILES:
     PID directory: $PID_DIR
@@ -655,6 +656,15 @@ internal-launch)
   if [[ $1 =~ ^[0-9]+$ ]]; then
     launch_random_wallpaper "$1"
     exit $?
+  # check if it's a local path (directory with project.json)
+  elif [ -d "$1" ] && [ -f "$1/project.json" ]; then
+    mkdir -p "$PID_DIR"
+    echo -e "${BLUE}📁 Launching local wallpaper: ${CYAN}$1${NC}"
+    launch_wallpaper_with_id "$1" "false"
+    exit $?
+  elif [ -d "$1" ]; then
+    echo -e "${RED}❌ Error: Directory found but no project.json in: ${CYAN}$1${NC}"
+    exit 1
   else
     echo -e "${RED}Unknown option or subcommand: $1${NC}"
     show_help


### PR DESCRIPTION
- add support for launching wallpapers from a local directory path
- validate that the directory contains `project.json`
- update help text to document the new local path option

closes #1237