### PR TITLE
✨feat(hypr): fullscreen mod the spire game

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -101,9 +101,11 @@ env = XDG_SESSION_DESKTOP,Hyprland
 # windowrule
 ## vim via wezterm for ime
 windowrule = float on, match:class ^(FloatingVim)$
-## mod the spire - force tiling
-windowrule = tile on, match:class ^(com-evacipated-cardcrawl-modthespire-Loader)$
+## mod the spire
+### launcher - force tiling
 windowrule = tile on, match:title ^(ModTheSpire)$
+### game - force true fullscreen (hides bar)
+windowrule = fullscreen on, match:class ^(com-evacipated-cardcrawl-modthespire-Loader)$, match:title negative:^(ModTheSpire)$
 # bind
 ## mainmod
 $mainMod = ALT


### PR DESCRIPTION
- separate `mod the spire` windowrules for launcher and game
- change launcher tiling to match by `title` instead of `class`
- add `fullscreen on` rule for game window with `negative` title match

closes #1239