### PR TITLE
✨feat(hypr/qs): add special workspace support

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -85,10 +85,16 @@ exec-once = hyprpaper
 exec-once = qs
 ## ime
 exec-once = fcitx5 -D
+## easyeffects
+exec-once = sleep 3 && easyeffects -w
 ## vesktop
-exec-once = vesktop --start-minimized
+exec-once = vesktop
+## spotify
+exec-once = spotify
+## btop in special workspace
+exec-once = [workspace special:btop silent] wezterm -e btop
 ## steam
-exec-once = steam -silent
+exec-once = steam
 # env
 ## for graphic
 env = WLR_DRM_NO_ATOMIC,1
@@ -106,6 +112,13 @@ windowrule = float on, match:class ^(FloatingVim)$
 windowrule = tile on, match:title ^(ModTheSpire)$
 ### game - force true fullscreen (hides bar)
 windowrule = fullscreen on, match:class ^(com-evacipated-cardcrawl-modthespire-Loader)$, match:title negative:^(ModTheSpire)$
+## special workspace auto-placement
+### vesktop
+windowrule = workspace special:vesktop silent, match:class ^(vesktop)$
+### spotify
+windowrule = workspace special:spotify silent, match:class ^(spotify)$
+### steam
+windowrule = workspace special:game silent, match:class ^(steam)$
 # bind
 ## mainmod
 $mainMod = ALT
@@ -166,14 +179,20 @@ bindm = $mainMod SHIFT, mouse:273, resizewindow
 ## shortcuts
 ### application launcher
 bind = $mainMod, Space, exec, qs ipc call launcher toggle
-### btop via wezterm (like taskmgr)
-bind = CTRL SHIFT, ESCAPE, exec, wezterm -e btop
+### btop (like taskmgr)
+bind = CTRL SHIFT, ESCAPE, togglespecialworkspace, btop
 ### clipboard history via quickshell launcher
 bind = CTRL SHIFT, Q, exec, qs ipc call launcher clipboard
 ### browser
 bind = SUPER, B, exec, vivaldi
 ### nemo (like explorer)
 bind = SUPER, E, exec, nemo
+### special workspace
+bind = $mainMod, slash, togglespecialworkspace, stash
+bind = $mainMod SHIFT, slash, movetoworkspace, special:stash
+bind = SUPER, V, togglespecialworkspace, vesktop
+bind = SUPER, M, togglespecialworkspace, spotify
+bind = SUPER, G, togglespecialworkspace, game
 ### kill active window
 bind = SUPER, Q, killactive
 ### terminal

--- a/configs/quickshell/Services/CompositorService.qml
+++ b/configs/quickshell/Services/CompositorService.qml
@@ -23,6 +23,10 @@ Singleton {
   property var displayScales: ({})
   property bool displayScalesLoaded: false
 
+  // Special workspace state per monitor
+  property var activeSpecialWorkspaces: ({})
+  signal specialWorkspaceChanged
+
   // Generic events
   signal workspaceChanged
   signal activeWindowChanged
@@ -161,6 +165,13 @@ Singleton {
                                         windowListChanged()
                                       })
 
+    if (backend.specialWorkspaceChanged) {
+      backend.specialWorkspaceChanged.connect(() => {
+                                                activeSpecialWorkspaces = backend.activeSpecialWorkspaces
+                                                specialWorkspaceChanged()
+                                              })
+    }
+
     // Property bindings
     backend.focusedWindowIndexChanged.connect(() => {
                                                 focusedWindowIndex = backend.focusedWindowIndex
@@ -265,6 +276,13 @@ Singleton {
       }
     }
     return windowsInWs
+  }
+
+  // Toggle special workspace
+  function toggleSpecialWorkspace(name) {
+    if (backend && backend.toggleSpecialWorkspace) {
+      backend.toggleSpecialWorkspace(name)
+    }
   }
 
   // Generic workspace switching

--- a/outputs/home-manager/hosts/yanoNixOs/gui/media.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/media.nix
@@ -9,35 +9,12 @@
   # home
   home = {
     packages = with pkgs; [
+      easyeffects
       evince
       qimgv
       mpv
       spotify
       totem
     ];
-  };
-  # services
-  services = {
-    easyeffects = {
-      enable = true;
-    };
-  };
-  # systemd
-  systemd = {
-    user = {
-      services = {
-        easyeffects = {
-          Service = {
-            ExecStart = lib.mkForce "${pkgs.easyeffects}/bin/easyeffects --gapplication-service";
-            TimeoutStartSec = lib.mkForce 30;
-            TimeoutStopSec = lib.mkForce 5;
-            Type = lib.mkForce "simple";
-          };
-          Unit = {
-            After = lib.mkForce [ "pipewire.service" ];
-          };
-        };
-      };
-    };
   };
 }


### PR DESCRIPTION
- add `stash` special workspace with `ALT + /` toggle
  and `ALT + SHIFT + /` to move window
- add dedicated special workspaces for `vesktop`,
  `spotify`, `steam`, and `btop`
- add keybindings: `SUPER + V` (vesktop),
  `SUPER + M` (spotify), `SUPER + G` (game),
  `CTRL + SHIFT + ESC` (btop)
- add `windowrule` to auto-place `vesktop`, `spotify`,
  and `steam` into their special workspaces
- add `exec-once` for `spotify`, `btop`, and
  `easyeffects` startup
- remove `--start-minimized` from `vesktop` and
  `-silent` from `steam` (replaced by `windowrule`)
- add QuickShell bar indicator for active special
  workspace using `activespecial` IPC event
- track special workspace state per monitor in
  `HyprlandService` and `CompositorService`
- replace `easyeffects` systemd service with
  `exec-once` launch using `-w` flag for tray support

closes #1243