### PR TITLE
✨feat(wallpaper-engine): add `autostart` subcommand

### DIFF
--- a/configs/default.nix
+++ b/configs/default.nix
@@ -36,7 +36,12 @@ let
       '';
     };
     "hypr/hypridle.conf".source = ./hypr/hypridle.conf;
-    "hypr/hyprpaper.conf".source = ./hypr/hyprpaper.conf;
+    "hypr/hyprpaper.conf" = {
+      source = ./hypr/hyprpaper.conf;
+      onChange = ''
+        (sleep 5 && $HOME/.local/bin/wallpaper-engine autostart) &>/dev/null &
+      '';
+    };
   };
   # zsh config subdirectories (excluding .zshrc/.zshenv which are managed by programs.zsh)
   zshContents = builtins.readDir ./zsh;

--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -81,6 +81,7 @@ exec-once = blueman-applet
 exec-once = hyprctl dispatch workspace 4
 ## wallpaper
 exec-once = hyprpaper
+exec-once = sleep 5 && $HOME/.local/bin/wallpaper-engine autostart
 ## bar
 exec-once = qs
 ## ime


### PR DESCRIPTION
- add `autostart` subcommand to `wallpaper-engine.sh` that
  reads `~/.config/wallpaper-engine/config` for settings
- support `ENABLED`, `WALLPAPER_PATH`, `INTERVAL`, and
  `ALL_TYPES` config options
- add `exec-once` in `hyprland.conf` to start
  `wallpaper-engine autostart` after `hyprpaper`
- add `onChange` hook to `hyprpaper.conf` in `default.nix`
  to restart `wallpaper-engine` after `nix run #update`

closes #1247