### PR TITLE
🐞fix(wallpaper-engine): fix background layer conflict

### DIFF
--- a/configs/default.nix
+++ b/configs/default.nix
@@ -36,12 +36,7 @@ let
       '';
     };
     "hypr/hypridle.conf".source = ./hypr/hypridle.conf;
-    "hypr/hyprpaper.conf" = {
-      source = ./hypr/hyprpaper.conf;
-      onChange = ''
-        (sleep 5 && $HOME/.local/bin/wallpaper-engine autostart) &>/dev/null &
-      '';
-    };
+    "hypr/hyprpaper.conf".source = ./hypr/hyprpaper.conf;
   };
   # zsh config subdirectories (excluding .zshrc/.zshenv which are managed by programs.zsh)
   zshContents = builtins.readDir ./zsh;

--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -228,7 +228,7 @@ bind = SUPER SHIFT, C, exec, hyprpicker -a -f hex
 #### reload hyprland config
 bind = SUPER SHIFT, H, exec, sh -c 'hyprctl reload && notify-send "Hyprland" "Configuration reloaded!"'
 #### reload quickshell config
-bind = SUPER SHIFT, B, exec, sh -c 'pkill quickshell; qs & sleep 3 && notify-send "QuickShell" "Configuration reloaded!"'
+bind = SUPER SHIFT, B, exec, sh -c 'pkill quickshell; qs & sleep 3 && notify-send "QuickShell" "Configuration reloaded!" && $HOME/.local/bin/wallpaper-engine autostart'
 ### system controls
 #### reboot
 bind = SUPER SHIFT, R, exec, qs ipc call sessionMenu reboot

--- a/configs/quickshell/Services/IPCService.qml
+++ b/configs/quickshell/Services/IPCService.qml
@@ -226,6 +226,9 @@ Item {
     function enableAutomation() {
       Settings.data.wallpaper.randomEnabled = true
     }
+    function disableBackground() {
+      Settings.data.wallpaper.enabled = false
+    }
   }
 
   IpcHandler {

--- a/ops/scripts/nixos/wallpaper-engine.sh
+++ b/ops/scripts/nixos/wallpaper-engine.sh
@@ -666,7 +666,13 @@ autostart)
   else
     launch_random_wallpaper "${INTERVAL:-$DEFAULT_INTERVAL}"
   fi
-  exit $?
+  result=$?
+  # kill hyprpaper and disable quickshell background only after wallpaper-engine started successfully
+  if [ $result -eq 0 ]; then
+    pkill -x hyprpaper 2>/dev/null || true
+    qs ipc call wallpaper disableBackground 2>/dev/null || true
+  fi
+  exit $result
   ;;
 get-wallpapers)
   # internal command for rotation script


### PR DESCRIPTION
- kill `hyprpaper` after successful `wallpaper-engine`
  start to prevent layer conflict
- add `disableBackground` IPC to `QuickShell` to unload
  `Background.qml` panels covering `wallpaper-engine`
- re-run `autostart` after `QuickShell` reload
  (`SUPER+SHIFT+B`) to restore wallpaper state
- revert unnecessary `onChange` hook in `default.nix`

related to #1247

closes #1251