### PR TITLE
🐞fix(ai): reinstall `clip-interrogator` after venv recreation

### DIFF
--- a/outputs/home-manager/hosts/yanoNixOs/gui/ai.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/ai.nix
@@ -306,6 +306,12 @@
             PATCH_EOF
                             echo "CLIP Interrogator node patched successfully!"
                             cd ../..
+                          else
+                            # Ensure dependencies are installed (e.g. after venv recreation)
+                            if ! python -c "import clip_interrogator" 2>/dev/null; then
+                              echo "Reinstalling CLIP Interrogator dependencies..."
+                              pip install clip-interrogator==0.6.0
+                            fi
                           fi
                         fi
                         # Start InvokeAI


### PR DESCRIPTION
- add `else` branch to check if `clip-interrogator` package is
  installed when the node directory already exists
- run `pip install clip-interrogator==0.6.0` automatically if the
  import check fails (e.g. after python version upgrade)

closes #1257