### PR TITLE
🐞fix(nix): use `nodejs_latest` instead of `nodePackages_latest.nodejs`

### DIFF
--- a/outputs/home-manager/shared-modules/cli/web.nix
+++ b/outputs/home-manager/shared-modules/cli/web.nix
@@ -31,7 +31,7 @@ in
         packages = with pkgs; [
           bun
           deno
-          nodePackages_latest.nodejs
+          nodejs_latest
           nodePackages_latest.pnpm
           posting
           wget


### PR DESCRIPTION
- `nodePackages_latest.nodejs` now resolves to `nodejs-slim` which
  does not include `npm`
- switch to `nodejs_latest` to get the full nodejs package with `npm`
  bundled, fixing mason `yamlls` installation failure

closes #1263