### PR TITLE
✨feat(hypr): tile steam main window

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -119,6 +119,7 @@ windowrule = workspace special:vesktop silent, match:class ^(vesktop)$
 ### spotify
 windowrule = workspace special:spotify silent, match:class ^(spotify)$
 ### steam
+windowrule = tile on, match:class ^(steam)$, match:title ^(Steam)$
 windowrule = workspace special:game silent, match:class ^(steam)$
 # bind
 ## mainmod


### PR DESCRIPTION
- add `tile on` windowrule for steam main window
- match only `class:steam` with `title:Steam` to
  avoid tiling sub-windows like settings or dialogs

closes #1265