### PR TITLE
🐞fix(wallpaper-engine): disable QuickShell wallpaper

### DIFF
--- a/configs/quickshell/settings.json
+++ b/configs/quickshell/settings.json
@@ -294,7 +294,7 @@
     "defaultWallpaper": "~/.local/share/wallpapers/wall_8K.png",
     "directory": "~/.local/share/wallpapers",
     "enableMultiMonitorDirectories": false,
-    "enabled": true,
+    "enabled": false,
     "fillColor": "#000000",
     "fillMode": "crop",
     "monitors": [


### PR DESCRIPTION
- disable `wallpaper.enabled` in `settings.json` to prevent
  `quickshell-wallpaper` layer from covering
  `linux-wallpaperengine` after `nix run .#update`
- `settings.json` is a read-only symlink to nix store, so
  the in-memory `disableBackground` IPC was reset on every
  home-manager activation

## wallpaper-engine recent changes summary
1. e12d0322 - add local path wallpaper launch support
2. ea1a1185 - add `autostart` subcommand
3. b06cdbb9 - fix background layer conflict (kill
   `hyprpaper` + `disableBackground` IPC)
4. this commit - disable `wallpaper.enabled` in
   `settings.json`

## files to revert when removing wallpaper-engine
- `configs/quickshell/settings.json`
  -> set `wallpaper.enabled` back to `true`
- `configs/hypr/hyprland.conf`
  -> remove `wallpaper-engine autostart` from `exec-once`
  -> remove `wallpaper-engine autostart` from `SUPER+SHIFT+B`
- `configs/quickshell/Services/IPCService.qml`
  -> remove `disableBackground()` function
- `ops/scripts/nixos/wallpaper-engine.sh`
  -> remove `pkill hyprpaper` and `disableBackground` call
     from `autostart` subcommand

closes #1267