### PR TITLE
🐞fix(hypr): fix mod the spire launch for proton

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -108,11 +108,6 @@ env = XDG_SESSION_DESKTOP,Hyprland
 # windowrule
 ## vim via wezterm for ime
 windowrule = float on, match:class ^(FloatingVim)$
-## mod the spire
-### launcher - force tiling
-windowrule = tile on, match:title ^(ModTheSpire)$
-### game - force true fullscreen (hides bar)
-windowrule = fullscreen on, match:class ^(com-evacipated-cardcrawl-modthespire-Loader)$, match:title negative:^(ModTheSpire)$
 ## special workspace auto-placement
 ### vesktop
 windowrule = workspace special:vesktop silent, match:class ^(vesktop)$

--- a/ops/scripts/nixos/ModTheSpire.sh
+++ b/ops/scripts/nixos/ModTheSpire.sh
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
-# Mod the Spire Launcher Script
-
-# set working directory
-cd $HOME/.local/share/Steam/steamapps/common/SlayTheSpire || exit 1
-
-# use steam-run to provide Steam libraries and run ModTheSpire
-exec steam-run ./jre/bin/java -jar $HOME/.local/share/Steam/steamapps/workshop/content/646570/1605060445/ModTheSpire.jar
+# Mod the Spire Launcher Script (via Steam/Proton)
+exec xdg-open "steam://launch/646570/option1"


### PR DESCRIPTION
- remove `windowrule` for mod the spire from
  `hyprland.conf` since `fullscreen` windowrule does
  not work on xwayland windows
- change `ModTheSpire.sh` to launch via
  `steam://launch/646570/option1` (proton "with mods")
  instead of `steam-run` with native java which crashes
  on nvidia 570.x with lwjgl3/glfw

closes #1293