### PR TITLE
🐞fix(hypr/niri): fix fcitx5 not starting

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -85,7 +85,7 @@ exec-once = sleep 5 && $HOME/.local/bin/wallpaper-engine autostart
 ## bar
 exec-once = qs
 ## ime
-exec-once = fcitx5 -D
+exec-once = sleep 1 && fcitx5 -D
 ## easyeffects
 exec-once = sleep 3 && easyeffects -w
 ## vesktop

--- a/configs/niri/config.kdl
+++ b/configs/niri/config.kdl
@@ -115,7 +115,7 @@ spawn-at-startup "sh" "-c" "sleep 2 && systemctl --user restart xdg-desktop-port
 //// quickShell
 spawn-at-startup "qs"
 //// ime
-spawn-at-startup "fcitx5" "-D"
+spawn-at-startup "sh" "-c" "sleep 1 && fcitx5 -D"
 //// vesktop
 spawn-at-startup "sh" "-c" "sleep 5 && vesktop --start-minimized"
 //// steam


### PR DESCRIPTION
- add 1 second delay before `fcitx5 -D` in
  `hyprland.conf` `exec-once`
- add 1 second delay before `fcitx5 -D` in
  `niri/config.kdl` `spawn-at-startup`
- ensures compositor initialization (xwayland,
  d-bus) completes before fcitx5 connects

closes #1298