### PR TITLE
🐞fix(fcitx5): fix ime not responding on wayland

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,7 @@ ifeq ($(IS_NIXOS),1)
 	@echo ""
 	rm -fr $$HOME/.config/claude/CLAUDE.md
 	rm -fr $$HOME/.config/fcitx5/config
+	rm -fr $$HOME/.config/fcitx5/profile
 	nix run .#homeConfigurations."yanosea@yanoNixOs".activationPackage
 	@echo "$(COLOR_DONE)apply home configuration done!$(COLOR_RESET)"
 	@echo ""
@@ -238,6 +239,7 @@ ifeq ($(IS_NIXOS),1)
 	@echo ""
 	rm -fr $$HOME/.config/claude/CLAUDE.md
 	rm -fr $$HOME/.config/fcitx5/config
+	rm -fr $$HOME/.config/fcitx5/profile
 	EXPERIMENTAL_MODE=1 nix run --impure .#homeConfigurations."yanosea@yanoNixOs".activationPackage
 	@echo ""
 	@echo "$(COLOR_DONE)apply home configuration experimentally done!$(COLOR_RESET)"

--- a/configs/fcitx5/profile
+++ b/configs/fcitx5/profile
@@ -1,0 +1,22 @@
+[Groups/0]
+# Group Name
+Name=Default
+# Layout
+Default Layout=us
+# Default Input Method
+DefaultIM=skk
+
+[Groups/0/Items/0]
+# Name
+Name=keyboard-us
+# Layout
+Layout=
+
+[Groups/0/Items/1]
+# Name
+Name=skk
+# Layout
+Layout=
+
+[GroupOrder]
+0=Default

--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -99,9 +99,6 @@ exec-once = steam
 # env
 ## for graphic
 env = WLR_DRM_NO_ATOMIC,1
-## for ime
-env = QT_IM_MODULE,fcitx
-env = XMODIFIERS,@im=fcitx
 env = XDG_CURRENT_DESKTOP,Hyprland
 env = XDG_SESSION_TYPE,wayland
 env = XDG_SESSION_DESKTOP,Hyprland

--- a/configs/niri/config.kdl
+++ b/configs/niri/config.kdl
@@ -124,9 +124,6 @@ spawn-at-startup "steam" "-silent"
 environment {
     //// for graphic
     WLR_DRM_NO_ATOMIC "1"
-    //// for ime
-    QT_IM_MODULE "fcitx"
-    XMODIFIERS "@im=fcitx"
     XDG_CURRENT_DESKTOP "niri"
     XDG_SESSION_TYPE "wayland"
     XDG_SESSION_DESKTOP "niri"

--- a/outputs/apps/default.nix
+++ b/outputs/apps/default.nix
@@ -38,6 +38,7 @@ let
       preHomeCommands = ''
         rm -fr "$HOME/.config/claude/CLAUDE.md"
         rm -fr "$HOME/.config/fcitx5/config"
+        rm -fr "$HOME/.config/fcitx5/profile"
       '';
     };
     # nixos (wsl)


### PR DESCRIPTION
- remove `QT_IM_MODULE` and `XMODIFIERS` env vars from
  `hyprland.conf` and `niri/config.kdl` to let wayland
  `text-input-v3` protocol handle ime natively
- add `fcitx5/profile` with `skk` as default input method
- add `profile` removal to `preHomeCommands` in
  `outputs/apps/default.nix` and `Makefile` to prevent
  symlink conflicts during home-manager activation

closes #1305