### PR TITLE
✨feat(vim): set `viminfofile` to xdg state home

### DIFF
--- a/configs/vim/vimrc
+++ b/configs/vim/vimrc
@@ -66,6 +66,8 @@ if !isdirectory(undo_dir)
 endif
 set undofile
 exe 'set undodir=' .. undo_dir
+" viminfo
+set viminfofile=$XDG_STATE_HOME/vim/viminfo
 " standard plugin
 filetype plugin on
 let g:netrw_liststyle=1


### PR DESCRIPTION
- add `viminfofile` setting to store viminfo in
  `$XDG_STATE_HOME/vim/viminfo`

closes #1312