### PR TITLE
✨feat(bluetooth/game): add bt controller support

### DIFF
--- a/outputs/nixos/yanoNixOs/desktop/bluetooth.nix
+++ b/outputs/nixos/yanoNixOs/desktop/bluetooth.nix
@@ -4,6 +4,14 @@
   hardware = {
     bluetooth = {
       enable = true;
+      powerOnBoot = true;
+      settings = {
+        General = {
+          ControllerMode = "dual";
+          FastConnectable = true;
+          Experimental = true;
+        };
+      };
     };
   };
   # services

--- a/outputs/nixos/yanoNixOs/desktop/game.nix
+++ b/outputs/nixos/yanoNixOs/desktop/game.nix
@@ -1,5 +1,23 @@
 # nixos desktop game module
+{ pkgs, ... }:
 {
+  # boot
+  boot = {
+    kernelModules = [
+      "hid_sony"
+    ];
+  };
+  # hardware
+  hardware = {
+    # steam hardware udev rules (controllers, vr headsets, etc.)
+    steam-hardware = {
+      enable = true;
+    };
+    # xbox wireless controller bluetooth driver
+    xpadneo = {
+      enable = true;
+    };
+  };
   # programs
   programs = {
     steam = {
@@ -13,6 +31,13 @@
       remotePlay = {
         openFirewall = true;
       };
+    };
+  };
+  # services
+  services = {
+    # nintendo switch joy-con / pro controller daemon
+    joycond = {
+      enable = true;
     };
   };
 }


### PR DESCRIPTION
- add `powerOnBoot`, `ControllerMode`, `FastConnectable`,
  and `Experimental` settings to `bluetooth.nix`
- add `hid_sony` kernel module for ps4/ps5 controllers
- enable `steam-hardware` udev rules for generic
  controller support
- enable `xpadneo` driver for xbox wireless controllers
- enable `joycond` daemon for nintendo switch controllers

closes #1323