### PR TITLE
🐞fix(workflow): use PAT to create flake update PR

### DIFF
--- a/.github/workflows/update-nix-flake-dependencies.yml
+++ b/.github/workflows/update-nix-flake-dependencies.yml
@@ -121,7 +121,7 @@ jobs:
         if: steps.update-flake.outputs.changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.YANONIXFILES_AUTO_MERGE_PAT }}
           sign-commits: true
           commit-message: ${{ steps.update-flake.outputs.commit_message }}
           title: ${{ steps.update-flake.outputs.commit_title }}


### PR DESCRIPTION
- use `YANONIXFILES_AUTO_MERGE_PAT` instead of `GITHUB_TOKEN`
  in the `create-pull-request` step of
  `update-nix-flake-dependencies` workflow
- prevents subsequent workflow runs from becoming
  `action_required`, which caused `mergeStateStatus` to stay
  `UNSTABLE` and blocked auto-merge from completing

closes #1360