### PR TITLE
🐞fix(workflow): revert flake PR creation token

### DIFF
--- a/.github/workflows/update-nix-flake-dependencies.yml
+++ b/.github/workflows/update-nix-flake-dependencies.yml
@@ -121,7 +121,7 @@ jobs:
         if: steps.update-flake.outputs.changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.YANONIXFILES_AUTO_MERGE_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           sign-commits: true
           commit-message: ${{ steps.update-flake.outputs.commit_message }}
           title: ${{ steps.update-flake.outputs.commit_title }}


### PR DESCRIPTION
- revert `update-nix-flake-dependencies` to use `GITHUB_TOKEN`
  instead of `YANONIXFILES_AUTO_MERGE_PAT` for PR creation
- PAT-created PRs cannot be approved by the same account,
  causing auto-merge to fail with branch protection rules
- `GITHUB_TOKEN` (bot) creates PR; PAT (yanosea) approves,
  which satisfies the required owner-review protection

closes #1363