### PR TITLE
✨feat(desktop): enable quickshell wallpaper background

### DIFF
--- a/configs/quickshell/settings.json
+++ b/configs/quickshell/settings.json
@@ -294,7 +294,7 @@
     "defaultWallpaper": "~/.local/share/wallpapers/wall_8K.png",
     "directory": "~/.local/share/wallpapers",
     "enableMultiMonitorDirectories": false,
-    "enabled": false,
+    "enabled": true,
     "fillColor": "#000000",
     "fillMode": "crop",
     "monitors": [

--- a/outputs/home-manager/hosts/yanoNixOs/gui/desktop.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/desktop.nix
@@ -104,6 +104,7 @@
     windowManager = {
       hyprland = {
         enable = true;
+        configType = "hyprlang";
         # dummy
         settings = {
           env = [ ];


### PR DESCRIPTION
- set `wallpaper.enabled` to `true` in quickshell `settings.json`
  to restore background display when `wallpaper-engine` is disabled
- add `configType = "hyprlang"` to hyprland config in
  `desktop.nix`

closes #1388