### PR TITLE
🐞fix(hypr): fix config errors after upgrading to hyprland 0.55

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -70,7 +70,6 @@ misc {
 # layout
 dwindle {
     preserve_split = true
-    pseudotile = true
 }
 # exec-once (launch at startup)
 ## systemd session target
@@ -133,7 +132,7 @@ bind = $mainMod, right, resizeactive, 20 0
 bind = $mainMod, up, resizeactive, 0 -20
 bind = $mainMod, down, resizeactive, 0 20
 ### tailing window vertically
-bind = $mainMod, S, togglesplit
+bind = $mainMod, S, layoutmsg, togglesplit
 ### float active window
 bind = $mainMod SHIFT, Space, togglefloating
 ### maximize active window (keep bar visible)


### PR DESCRIPTION
- remove `dwindle:pseudotile` option removed in hyprland 0.55
- replace deprecated `togglesplit` dispatcher with `layoutmsg, togglesplit`

closes #1390