### PR TITLE
✨feat(desktop): compositor switcher and app-toggle

### DIFF
--- a/configs/default.nix
+++ b/configs/default.nix
@@ -17,6 +17,12 @@ let
     };
   };
   configFiles = lib.mapAttrs' mkEntry filteredContents;
+  # quickshell: force = true because QS writes settings.json back at runtime
+  quickshellOverride = {
+    "quickshell" = (configFiles."quickshell") // {
+      force = true;
+    };
+  };
   # hypr config files with custom onChange hook for hyprland.conf
   hyprConfigEntries = {
     "hypr/hyprland.conf" = {
@@ -55,9 +61,25 @@ in
       source = ./gemini;
       recursive = true;
     };
+    ".local/bin/niri-app-toggle" = {
+      executable = true;
+      text = ''
+        #!/usr/bin/env bash
+        APP_ID="$1"
+        shift
+        WINDOWS=$(niri msg -j windows 2>/dev/null)
+        UNFOCUSED_ID=$(printf '%s' "$WINDOWS" | jq -r --arg a "$APP_ID" \
+          'first(.[] | select(.app_id == $a and .is_focused == false) | .id) // empty')
+        if [ -n "$UNFOCUSED_ID" ]; then
+          niri msg action focus-window --id "$UNFOCUSED_ID"
+        elif ! printf '%s' "$WINDOWS" | jq -e --arg a "$APP_ID" 'any(.[]; .app_id == $a)' >/dev/null 2>&1; then
+          exec "$@"
+        fi
+      '';
+    };
   };
   # xdg
   xdg = {
-    configFile = configFiles // hyprConfigEntries // zshConfigEntries;
+    configFile = configFiles // quickshellOverride // hyprConfigEntries // zshConfigEntries;
   };
 }

--- a/configs/niri/config.kdl
+++ b/configs/niri/config.kdl
@@ -381,6 +381,15 @@ binds {
     Super+E {
         spawn "nemo"
     }
+    Super+V {
+        spawn-sh "$HOME/.local/bin/niri-app-toggle vesktop vesktop"
+    }
+    Super+M {
+        spawn-sh "$HOME/.local/bin/niri-app-toggle spotify spotify"
+    }
+    Super+G {
+        spawn-sh "$HOME/.local/bin/niri-app-toggle steam steam"
+    }
     Super+L {
         spawn "qs" "ipc" "call" "lockScreen" "lock"
     }

--- a/configs/quickshell/Modules/ControlCenter/Cards/CompositorCard.qml
+++ b/configs/quickshell/Modules/ControlCenter/Cards/CompositorCard.qml
@@ -1,0 +1,113 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.Commons
+import qs.Services
+import qs.Widgets
+
+NBox {
+  id: root
+
+  RowLayout {
+    anchors.fill: parent
+    anchors.margins: Style.marginM
+    spacing: Style.marginL
+
+    // Left: current running compositor
+    NIcon {
+      icon: "device-desktop"
+      pointSize: Style.fontSizeXXL
+      color: Color.mPrimary
+      Layout.alignment: Qt.AlignVCenter
+    }
+
+    ColumnLayout {
+      spacing: 0
+      Layout.alignment: Qt.AlignVCenter
+
+      NText {
+        text: CompositorPreferenceService.currentName
+        font.weight: Style.fontWeightBold
+      }
+      NText {
+        text: "running"
+        pointSize: Style.fontSizeXS
+        color: Color.mOnSurfaceVariant
+      }
+    }
+
+    Item {
+      Layout.fillWidth: true
+    }
+
+    // Right: login-default selector + optional logout button
+    RowLayout {
+      spacing: Style.marginXS
+      Layout.alignment: Qt.AlignVCenter
+
+      NText {
+        text: "Default:"
+        pointSize: Style.fontSizeXS
+        color: Color.mOnSurfaceVariant
+      }
+
+      // Niri pill
+      Rectangle {
+        implicitWidth: niriLabel.implicitWidth + Style.marginM * 2
+        implicitHeight: Math.round(Style.baseWidgetSize * 0.6 * Style.uiScaleRatio)
+        radius: Style.radiusS
+        color: CompositorPreferenceService.preferredCompositor === "niri-session" ? Color.mPrimary : Color.mSurfaceVariant
+        Behavior on color { ColorAnimation { duration: Style.animationFast } }
+
+        NText {
+          id: niriLabel
+          anchors.centerIn: parent
+          text: "Niri"
+          pointSize: Style.fontSizeXS
+          font.weight: Style.fontWeightMedium
+          color: CompositorPreferenceService.preferredCompositor === "niri-session" ? Color.mOnPrimary : Color.mOnSurfaceVariant
+          Behavior on color { ColorAnimation { duration: Style.animationFast } }
+        }
+        MouseArea {
+          anchors.fill: parent
+          cursorShape: Qt.PointingHandCursor
+          onClicked: CompositorPreferenceService.setPreferred("niri-session")
+        }
+      }
+
+      // Hyprland pill
+      Rectangle {
+        implicitWidth: hyprLabel.implicitWidth + Style.marginM * 2
+        implicitHeight: Math.round(Style.baseWidgetSize * 0.6 * Style.uiScaleRatio)
+        radius: Style.radiusS
+        color: CompositorPreferenceService.preferredCompositor === "start-hyprland" ? Color.mPrimary : Color.mSurfaceVariant
+        Behavior on color { ColorAnimation { duration: Style.animationFast } }
+
+        NText {
+          id: hyprLabel
+          anchors.centerIn: parent
+          text: "Hyprland"
+          pointSize: Style.fontSizeXS
+          font.weight: Style.fontWeightMedium
+          color: CompositorPreferenceService.preferredCompositor === "start-hyprland" ? Color.mOnPrimary : Color.mOnSurfaceVariant
+          Behavior on color { ColorAnimation { duration: Style.animationFast } }
+        }
+        MouseArea {
+          anchors.fill: parent
+          cursorShape: Qt.PointingHandCursor
+          onClicked: CompositorPreferenceService.setPreferred("start-hyprland")
+        }
+      }
+
+      // Logout button — only when current session differs from login default
+      NIconButton {
+        visible: CompositorPreferenceService.currentName !== CompositorPreferenceService.preferredName
+        icon: "logout"
+        tooltipText: "Switch to " + CompositorPreferenceService.preferredName + " (logout)"
+        colorFg: Color.mError
+        colorBgHover: Color.mError
+        colorFgHover: Color.mOnError
+        onClicked: CompositorPreferenceService.switchTo(CompositorPreferenceService.preferredCompositor)
+      }
+    }
+  }
+}

--- a/configs/quickshell/Modules/ControlCenter/ControlCenterPanel.qml
+++ b/configs/quickshell/Modules/ControlCenter/ControlCenterPanel.qml
@@ -41,6 +41,9 @@ NPanel {
       case "media-sysmon-card":
         height += mediaSysMonHeight
         break
+      case "compositor-card":
+        height += compositorHeight
+        break
       default:
         break
       }
@@ -62,6 +65,7 @@ NPanel {
   readonly property int audioHeight: Math.round(60 * Style.uiScaleRatio)
   readonly property int weatherHeight: Math.round(190 * Style.uiScaleRatio)
   readonly property int mediaSysMonHeight: Math.round(260 * Style.uiScaleRatio)
+  readonly property int compositorHeight: Math.round(64 * Style.uiScaleRatio)
 
   panelContent: Item {
     id: content
@@ -91,6 +95,8 @@ NPanel {
               return weatherHeight
             case "media-sysmon-card":
               return mediaSysMonHeight
+            case "compositor-card":
+              return compositorHeight
             default:
               return 0
             }
@@ -107,6 +113,8 @@ NPanel {
               return weatherCard
             case "media-sysmon-card":
               return mediaSysMonCard
+            case "compositor-card":
+              return compositorCard
             }
           }
         }
@@ -131,6 +139,11 @@ NPanel {
     Component {
       id: weatherCard
       WeatherCard {}
+    }
+
+    Component {
+      id: compositorCard
+      CompositorCard {}
     }
 
     Component {

--- a/configs/quickshell/Services/CompositorPreferenceService.qml
+++ b/configs/quickshell/Services/CompositorPreferenceService.qml
@@ -1,0 +1,87 @@
+pragma Singleton
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import qs.Services
+
+Singleton {
+  id: root
+
+  readonly property string prefsFilePath: "/var/lib/greetd/preferred-compositor"
+
+  // "niri-session" or "start-hyprland"
+  property string preferredCompositor: "start-hyprland"
+
+  readonly property string preferredName: preferredCompositor === "start-hyprland" ? "Hyprland" : "Niri"
+  readonly property string currentName: CompositorService.isHyprland ? "Hyprland" : "Niri"
+
+  function init() {
+    Logger.i("CompositorPreference", "Service started")
+    readProcess.running = true
+  }
+
+  // Read the preference file
+  Process {
+    id: readProcess
+    command: ["cat", root.prefsFilePath]
+    running: false
+
+    stdout: StdioCollector {
+      onStreamFinished: {
+        const raw = text.trim()
+        if (raw === "niri-session" || raw === "start-hyprland") {
+          root.preferredCompositor = raw
+          Logger.i("CompositorPreference", "Loaded:", raw)
+        } else {
+          root.preferredCompositor = "start-hyprland"
+          Logger.i("CompositorPreference", "File missing or invalid, defaulting to start-hyprland")
+        }
+      }
+    }
+  }
+
+  // Write process
+  Process {
+    id: writeProcess
+    running: false
+    property string pendingValue: ""
+
+    onExited: function (exitCode) {
+      if (exitCode === 0) {
+        root.preferredCompositor = pendingValue
+        Logger.i("CompositorPreference", "Saved:", pendingValue)
+      } else {
+        Logger.e("CompositorPreference", "Write failed, exit:", exitCode)
+      }
+    }
+  }
+
+  // Set the preferred compositor for next login
+  function setPreferred(compositor) {
+    if (compositor !== "niri-session" && compositor !== "start-hyprland") {
+      Logger.w("CompositorPreference", "Invalid value:", compositor)
+      return
+    }
+    writeProcess.pendingValue = compositor
+    writeProcess.command = ["sh", "-c", "printf '%s' '" + compositor + "' > '" + root.prefsFilePath + "'"]
+    writeProcess.running = true
+  }
+
+  // Set preferred then log out to switch compositor
+  function switchTo(compositor) {
+    setPreferred(compositor)
+    switchTimer.start()
+  }
+
+  Timer {
+    id: switchTimer
+    interval: 600
+    repeat: false
+    onTriggered: {
+      Logger.i("CompositorPreference", "Logging out to switch compositor")
+      CompositorService.logout()
+    }
+  }
+}

--- a/configs/quickshell/settings.json
+++ b/configs/quickshell/settings.json
@@ -134,6 +134,10 @@
       },
       {
         "enabled": true,
+        "id": "compositor-card"
+      },
+      {
+        "enabled": true,
         "id": "audio-card"
       },
       {

--- a/configs/quickshell/shell.qml
+++ b/configs/quickshell/shell.qml
@@ -86,6 +86,7 @@ ShellRoot {
         IdleInhibitorService.init()
         PowerProfileService.init()
         DistroService.init()
+        CompositorPreferenceService.init()
       }
 
       Background {}

--- a/outputs/nixos/yanoNixOs/desktop/default.nix
+++ b/outputs/nixos/yanoNixOs/desktop/default.nix
@@ -7,6 +7,7 @@
     ./fuse.nix
     ./game.nix
     ./graphics-tools.nix
+    ./greetd.nix
     ./hwclock.nix
     ./hyprland.nix
     ./niri.nix

--- a/outputs/nixos/yanoNixOs/desktop/greetd.nix
+++ b/outputs/nixos/yanoNixOs/desktop/greetd.nix
@@ -1,0 +1,27 @@
+# nixos desktop greetd module
+{ pkgs, username, ... }:
+let
+  prefsFile = "/var/lib/greetd/preferred-compositor";
+  sessionLauncher = pkgs.writeShellScript "greetd-session-launcher" ''
+    SESSION=$(cat "${prefsFile}" 2>/dev/null | tr -d '[:space:]')
+    case "$SESSION" in
+      niri-session|start-hyprland) ;;
+      *) SESSION="start-hyprland" ;;
+    esac
+    exec ${pkgs.tuigreet}/bin/tuigreet --time --remember --cmd "$SESSION"
+  '';
+in
+{
+  systemd.tmpfiles.rules = [
+    "d /var/lib/greetd 0770 ${username} greeter -"
+    "f /var/lib/greetd/preferred-compositor 0660 ${username} greeter - start-hyprland"
+  ];
+
+  services.greetd = {
+    enable = true;
+    settings.default_session = {
+      command = "${sessionLauncher}";
+      user = "greeter";
+    };
+  };
+}

--- a/outputs/nixos/yanoNixOs/desktop/security.nix
+++ b/outputs/nixos/yanoNixOs/desktop/security.nix
@@ -1,5 +1,5 @@
 # nixos desktop security module
-{ pkgs, username, ... }:
+{ pkgs, ... }:
 {
   # programs
   programs = {
@@ -28,22 +28,6 @@
     gnome = {
       gnome-keyring = {
         enable = true;
-      };
-    };
-    greetd = {
-      enable = true;
-      settings = {
-        default_session = {
-          # hyprland
-          command = ''
-            ${pkgs.tuigreet}/bin/tuigreet --time --remember --cmd start-hyprland
-          '';
-          # niri
-          # command = ''
-          #   ${pkgs.tuigreet}/bin/tuigreet --time --remember --cmd niri-session
-          # '';
-          user = "greeter";
-        };
       };
     };
   };


### PR DESCRIPTION
  - add `greetd.nix` with session launcher reading `/var/lib/greetd/preferred-compositor`
  - add `CompositorPreferenceService` for reading and writing the pref file
  - add `CompositorCard` to the control center for selecting and switching compositor
  - add `niri-app-toggle` script to focus or launch apps by `app_id`
  - add niri keybinds `Super+V/M/G` for vesktop, spotify, and steam
  - move `greetd` config from `security.nix` to dedicated `greetd.nix`
  - fix `quickshell` config with `force = true` to allow runtime writes

closes #1395