### PR TITLE
🐞fix(rclone): skip restart on home-manager switch

### DIFF
--- a/outputs/home-manager/hosts/yanoNixOs/cli/google-drive.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/cli/google-drive.nix
@@ -123,9 +123,11 @@ in
             # Prevent timer from killing manual execution
             RefuseManualStart = false;
             RefuseManualStop = false;
+            X-SwitchMethod = "keep-old";
           };
           Service = {
             Type = "oneshot";
+            RemainAfterExit = true;
             ExecStart = "${rcloneBisyncScript}";
             ExecStopPost = "${rcloneCleanupScript}";
             StandardOutput = "journal";


### PR DESCRIPTION
- add `X-SwitchMethod = "keep-old"` to `Unit` section to prevent
  `sd-switch` from restarting bisync when unit file changes on
  `nix run .#update`, which caused activation to hang indefinitely
- add `RemainAfterExit = true` to keep service `active` after
  bisync completes, preventing home-manager from re-triggering it

closes #1403