### PR TITLE
🐞fix(hypr): fix spotify windowrule class name

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -108,7 +108,7 @@ windowrule = float on, match:class ^(FloatingVim)$
 ### vesktop
 windowrule = workspace special:vesktop silent, match:class ^(vesktop)$
 ### spotify
-windowrule = workspace special:spotify silent, match:class ^(spotify)$
+windowrule = workspace special:spotify silent, match:class ^(Spotify)$
 ### steam
 windowrule = tile on, match:class ^(steam)$, match:title ^(Steam)$
 windowrule = workspace special:game silent, match:class ^(steam)$


### PR DESCRIPTION
- fix `match:class` from `^(spotify)$` to `^(Spotify)$`
  to match actual window class name

closes #1406