### PR TITLE
🐞fix(desktop): fix app startup issues on hyprland

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -86,7 +86,7 @@ exec-once = qs
 ## ime
 exec-once = sleep 1 && fcitx5 -D
 ## easyeffects
-exec-once = sleep 3 && easyeffects -w
+exec-once = sleep 10 && easyeffects -w
 ## vesktop
 exec-once = vesktop
 ## spotify
@@ -94,7 +94,7 @@ exec-once = spotify
 ## btop in special workspace
 exec-once = [workspace special:btop silent] wezterm -e btop
 ## steam
-exec-once = steam
+exec-once = sleep 5 && rm -f ~/.steam/steam.pid && systemd-run --user steam
 # env
 ## for graphic
 env = WLR_DRM_NO_ATOMIC,1

--- a/configs/quickshell/settings.json
+++ b/configs/quickshell/settings.json
@@ -8,7 +8,7 @@
     "position": "center",
     "sortByMostUsed": true,
     "terminalCommand": "wezterm start --",
-    "useApp2Unit": false
+    "useApp2Unit": true
   },
   "audio": {
     "cavaFrameRate": 60,

--- a/outputs/home-manager/hosts/yanoNixOs/gui/desktop.nix
+++ b/outputs/home-manager/hosts/yanoNixOs/gui/desktop.nix
@@ -64,6 +64,7 @@
     packages = (
       with pkgs;
       [
+        app2unit
         cava
         cliphist
         dconf


### PR DESCRIPTION
- fix steam `exec-once` failing due to `bwrap` 0.11.2 rejecting
  inherited `cap_sys_nice` from hyprland; use
  `systemd-run --user` to break capabilities chain
- increase `easyeffects` sleep from 3s to 10s to fix missing
  tray icon caused by qs statusnotifier watcher not ready
- add `app2unit` package and enable `useApp2Unit` in quickshell
  launcher to fix steam and game launches from launcher

closes #1415