### PR TITLE
🔧refactor(wrangler): install via deno npm

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,27 +110,6 @@
         "type": "github"
       }
     },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "wrangler",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -377,8 +356,7 @@
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_3",
         "sops-nix": "sops-nix",
-        "treefmt-nix": "treefmt-nix",
-        "wrangler": "wrangler"
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "rust-analyzer-src": {
@@ -488,28 +466,6 @@
         "owner": "numtide",
         "ref": "main",
         "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "wrangler": {
-      "inputs": {
-        "flake-parts": "flake-parts",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1779917523,
-        "narHash": "sha256-shkIJjXfNbAMwWvxEvGGE7WdwXEFOoD7CTHWIFW8Phg=",
-        "owner": "emrldnix",
-        "repo": "wrangler",
-        "rev": "0263422903a15fc51e9a9ed536f844fe1d8a1bdc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "emrldnix",
-        "ref": "master",
-        "repo": "wrangler",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -87,15 +87,6 @@
         };
       };
     };
-    ## wrangler
-    wrangler = {
-      url = "github:emrldnix/wrangler/master";
-      inputs = {
-        nixpkgs = {
-          follows = "nixpkgs";
-        };
-      };
-    };
   };
   outputs = inputs: {
     # apps

--- a/outputs/darwin/shared-modules/nix.nix
+++ b/outputs/darwin/shared-modules/nix.nix
@@ -22,13 +22,11 @@
         "https://cache.nixos.org"
         "https://claude-code.cachix.org"
         "https://nix-community.cachix.org"
-        "https://wrangler.cachix.org"
       ];
       trusted-public-keys = [
         "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
         "claude-code.cachix.org-1:YeXf2aNu7UTX8Vwrze0za1WEDS+4DuI2kVeWEE4fsRk="
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-        "wrangler.cachix.org-1:N/FIcG2qBQcolSpklb2IMDbsfjZKWg+ctxx0mSMXdSs="
       ];
       trusted-users = [
         "root"

--- a/outputs/home-manager/shared-modules/cli/web.nix
+++ b/outputs/home-manager/shared-modules/cli/web.nix
@@ -35,7 +35,6 @@ in
           pnpm
           posting
           wget
-          wrangler
           xh
         ];
       };
@@ -53,6 +52,13 @@ in
                   permissions = "--unstable-worker-options --allow-read --allow-net --allow-env --allow-run --allow-write --allow-import";
                 }
               ];
+              denoNpmPackages = [
+                {
+                  name = "wrangler";
+                  pkg = "wrangler@latest";
+                  permissions = "--allow-env --allow-read --allow-write --allow-net --allow-run --allow-sys";
+                }
+              ];
               syncDenoTools = pkgs.writeShellScript "sync-deno-tools" ''
                 set -euo pipefail
                 export PATH="${pkgs.deno}/bin:$PATH"
@@ -63,6 +69,13 @@ in
                     echo "  Installing/updating ${pkg.name}..."
                     ${pkgs.deno}/bin/deno install --global ${pkg.permissions} --name ${pkg.name} --reload --force ${pkg.url}
                   '') denoPackages
+                )}
+                echo "Syncing npm tools via Deno..."
+                ${builtins.concatStringsSep "\n" (
+                  map (pkg: ''
+                    echo "  Installing/updating ${pkg.name}..."
+                    ${pkgs.deno}/bin/deno install --global ${pkg.permissions} --name ${pkg.name} --force npm:${pkg.pkg}
+                  '') denoNpmPackages
                 )}
               '';
               script = pkgs.writeShellScript "sync-web-tools" ''

--- a/outputs/nixos/shared-modules/nix.nix
+++ b/outputs/nixos/shared-modules/nix.nix
@@ -23,7 +23,6 @@
         "https://cuda-maintainers.cachix.org"
         "https://hyprland.cachix.org"
         "https://nix-community.cachix.org"
-        "https://wrangler.cachix.org"
       ];
       trusted-public-keys = [
         "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
@@ -31,7 +30,6 @@
         "cuda-maintainers.cachix.org-1:0dq3bujKpuEPMCX6U4WylrUDZ9JyUG0VpVZa7CNfq5E="
         "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
         "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-        "wrangler.cachix.org-1:N/FIcG2qBQcolSpklb2IMDbsfjZKWg+ctxx0mSMXdSs="
       ];
       trusted-users = [
         "root"

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -105,8 +105,4 @@ inputs: [
   (final: prev: {
     jj-starship = inputs.jj-starship.packages.${prev.stdenv.hostPlatform.system}.default;
   })
-  ## wrangler
-  (final: prev: {
-    wrangler = inputs.wrangler.packages.${prev.stdenv.hostPlatform.system}.wrangler;
-  })
 ]


### PR DESCRIPTION
- remove `wrangler` flake input from `flake.nix`
- remove `wrangler` and `flake-parts` entries from `flake.lock`
- remove `wrangler` overlay from `overlays/default.nix`
- remove `wrangler.cachix.org` substituter and key from darwin
  and nixos nix settings
- remove `wrangler` from `home.packages` in `web.nix`
- add `denoNpmPackages` list in `web.nix` to manage npm tools
  via deno
- install `wrangler` via `deno install npm:wrangler` in
  activation script to bypass nix sandbox build failures

closes #1421