### PR TITLE
🐞fix(lazygit): fix resetCherryPick keybinding

### DIFF
--- a/configs/lazygit/config.yml
+++ b/configs/lazygit/config.yml
@@ -210,7 +210,7 @@ keybinding:
     pasteCommits: "V"
     tagCommit: "T"
     checkoutCommit: "<space>"
-    resetCherryPick: "<c-R>"
+    resetCherryPick: "<ctrl+shift+r>"
     copyCommitMessageToClipboard: "<c-y>"
     openLogMenu: "<c-l>"
     viewBisectOptions: "b"


### PR DESCRIPTION
- change `resetCherryPick` from `<c-R>` to `<ctrl+shift+r>`
- `<c-R>` is invalid since lazygit v0.62.0 introduced stricter
  keybinding validation

closes #1423