### PR TITLE
🐞fix(yazi): migrate config to v26.5.6 schema format

### DIFF
--- a/configs/yazi-alt/keymap.toml
+++ b/configs/yazi-alt/keymap.toml
@@ -1,6 +1,7 @@
-# A TOML linter such as https://taplo.tamasfe.dev/ can use this schema to validate your config.
+# A TOML linter such as https://github.com/tombi-toml/tombi can use this schema to validate your config.
 # If you encounter any issues, please make an issue at https://github.com/yazi-rs/schemas.
-"$schema" = "https://yazi-rs.github.io/schemas/keymap.json"
+
+#:schema https://yazi-rs.github.io/schemas/keymap.json
 
 [mgr]
 

--- a/configs/yazi-alt/theme.toml
+++ b/configs/yazi-alt/theme.toml
@@ -3,7 +3,7 @@
 
 # If you want to dynamically override their content based on dark/light mode, you can specify two different flavors
 # for dark and light modes under `[flavor]`, and do so in those flavors instead.
-"$schema" = "https://yazi-rs.github.io/schemas/theme.json"
+#:schema https://yazi-rs.github.io/schemas/theme.json
 
 # vim:fileencoding=utf-8:foldmethod=marker
 
@@ -216,16 +216,16 @@ rules = [
   # { mime = "inode/empty", fg = "red" },
 
   # Special files
-  { name = "*", is = "orphan", bg = "red" },
-  { name = "*", is = "exec", fg = "green" },
+  { url = "*", is = "orphan", bg = "red" },
+  { url = "*", is = "exec", fg = "green" },
 
   # Dummy files
-  # { name = "*", is = "dummy", bg = "red" },
-  # { name = "*/", is = "dummy", bg = "red" },
+  # { url = "*", is = "dummy", bg = "red" },
+  # { url = "*/", is = "dummy", bg = "red" },
 
   # Fallback
-  # { name = "*", fg = "white" },
-  { name = "*/", fg = "blue" },
+  # { url = "*", fg = "white" },
+  { url = "*/", fg = "blue" },
 ]
 
 # : }}}

--- a/configs/yazi-alt/yazi.toml
+++ b/configs/yazi-alt/yazi.toml
@@ -1,6 +1,7 @@
-# A TOML linter such as https://taplo.tamasfe.dev/ can use this schema to validate your config.
+# A TOML linter such as https://github.com/tombi-toml/tombi can use this schema to validate your config.
 # If you encounter any issues, please make an issue at https://github.com/yazi-rs/schemas.
-"$schema" = "https://yazi-rs.github.io/schemas/keymap.json"
+
+#:schema https://yazi-rs.github.io/schemas/yazi.json
 
 [mgr]
 show_hidden = true


### PR DESCRIPTION
- replace `"$schema"` toml key with `#:schema` comment
  as v26.5.6 no longer allows non-kebab-case keys
- rename `name` to `url` in `[filetype]` rules
- fix `yazi.toml` schema url from `keymap.json` to `yazi.json`
- update linter reference from `taplo` to `tombi`

closes #1425