### PR TITLE
🐞fix(vcs): add gnupg to sync-repos script PATH

### DIFF
--- a/outputs/home-manager/shared-modules/cli/vcs.nix
+++ b/outputs/home-manager/shared-modules/cli/vcs.nix
@@ -63,7 +63,7 @@ in
               ];
               script = pkgs.writeShellScript "sync-repos" ''
                 set -euo pipefail
-                export PATH=${pkgs.git}/bin:${pkgs.jujutsu}/bin:$PATH
+                export PATH=${pkgs.git}/bin:${pkgs.jujutsu}/bin:${pkgs.gnupg}/bin:$PATH
                 for repo in ${builtins.concatStringsSep " " repositories}; do
                   ${pkgs.ghq}/bin/ghq get --update "$repo"
                   repoPath="$HOME/ghq/$repo"


### PR DESCRIPTION
- add `gnupg` bin to `PATH` in `sync-repos` script
  to make gpg signing available during repo sync

closes #1434