### PR TITLE
🐞fix(nvim): pin nvim-treesitter to `main` branch

### DIFF
--- a/configs/nvim/lua/plugins/languages/lsp/config/nvim_treesitter.lua
+++ b/configs/nvim/lua/plugins/languages/lsp/config/nvim_treesitter.lua
@@ -2,6 +2,7 @@
 return {
 	{
 		"nvim-treesitter/nvim-treesitter",
+		branch = "main",
 		lazy = false,
 		build = ":TSUpdate",
 		config = function()


### PR DESCRIPTION
- add `branch = "main"` to nvim-treesitter plugin spec to prevent
  lazy.nvim from reverting to the old `master` branch on update
- the `master` branch lacks `get_installed` in the top-level
  module, causing a nil value error on startup

closes #1439