### PR TITLE
✨feat(dock): add spotify to the left of wezterm

### DIFF
--- a/outputs/darwin/shared-modules/defaults/dock.nix
+++ b/outputs/darwin/shared-modules/defaults/dock.nix
@@ -32,6 +32,9 @@
             app = "/Applications/Vesktop.app";
           }
           {
+            app = "/Applications/Spotify.app";
+          }
+          {
             app = "/Applications/WezTerm.app";
           }
           {


### PR DESCRIPTION
- add `/Applications/Spotify.app` to `persistent-apps` in
  `dock.nix`, positioned left of `WezTerm`

closes #1441