### PR TITLE
✨feat(nixos): enable fstrim and performance governor

### DIFF
--- a/outputs/nixos/yanoNixOs/default.nix
+++ b/outputs/nixos/yanoNixOs/default.nix
@@ -82,14 +82,29 @@
       };
     };
   };
+  # power management
+  powerManagement = {
+    cpuFreqGovernor = "performance";
+  };
   # services
   services = {
+    fstrim = {
+      enable = true;
+      interval = "daily";
+    };
     upower = {
       enable = true;
     };
   };
   # systemd
   systemd = {
+    timers = {
+      fstrim = {
+        timerConfig = {
+          Persistent = true;
+        };
+      };
+    };
     user = {
       settings = {
         Manager = {


### PR DESCRIPTION
- enable `fstrim` service with `daily` interval
- set `powerManagement.cpuFreqGovernor` to `performance`
- mark `fstrim` systemd timer as `Persistent`

closes #1449