### PR TITLE
🐞fix(nixos): skip service if rtc device is unavailable

### DIFF
--- a/outputs/nixos/yanoNixOs/desktop/hwclock.nix
+++ b/outputs/nixos/yanoNixOs/desktop/hwclock.nix
@@ -59,11 +59,13 @@
         conflicts = [ "shutdown.target" ];
         unitConfig = {
           DefaultDependencies = false;
+          ConditionPathExists = "/dev/rtc0";
         };
         serviceConfig = {
           Type = "oneshot";
           RemainAfterExit = true;
           ExecStart = "${pkgs.util-linux}/bin/hwclock --hctosys --localtime";
+          SuccessExitStatus = "0 1";
         };
         wantedBy = [ "basic.target" ];
       };


### PR DESCRIPTION
- add `ConditionPathExists = "/dev/rtc0"` to skip service
  when the device has not yet been created by udev at early boot
- add `SuccessExitStatus = "0 1"` to treat `hwclock` exit
  code 1 as success to prevent fatal boot warnings

closes #1459