### PR TITLE
🐞fix(sj): update deprecated jj options

### DIFF
--- a/configs/claude/commands/sj.md
+++ b/configs/claude/commands/sj.md
@@ -17,7 +17,9 @@
   3. `jj describe` command with the generated message
   4. `jj bookmark create` command to create a bookmark matching `gh issue develop` default format:
      - format: `<issue-number>-<issue-title-in-kebab-case>` (e.g., `1154-hypr-migrate-windowrulev2-to-new-windowrule-syntax`)
-  5. `jj git push` command to push the changes to remote with `-b <bookmark> --allow-new`
+  5. Two commands to push the bookmark:
+     - `jj bookmark track <bookmark>@origin` to track the bookmark on remote
+     - `jj git push -b <bookmark>` to push the changes to remote
   6. `gh pr create` command:
      - **IMPORTANT: use `--head <bookmark>` flag** (jj does not use git branches, so branch detection fails without this)
      - title:
@@ -30,7 +32,7 @@
      - assignee: same as issue (`@me`)
   7. `gh pr merge <pr-number>` command to merge the pull request
   8. cleanup commands:
-     - `jj git fetch && jj rebase -d main && jj bookmark delete <bookmark>`
+     - `jj git fetch && jj rebase -o main && jj bookmark delete <bookmark>`
 
 - Do not show the commit message separately; only show it in the commands.
 

--- a/configs/gemini/commands/sj.toml
+++ b/configs/gemini/commands/sj.toml
@@ -17,7 +17,9 @@ After understanding the changes, generate a commit message in English.
   3. `jj describe` command with the generated message
   4. `jj bookmark create` command to create a bookmark matching `gh issue develop` default format:
      - format: `<issue-number>-<issue-title-in-kebab-case>` (e.g., `1154-hypr-migrate-windowrulev2-to-new-windowrule-syntax`)
-  5. `jj git push` command to push the changes to remote with `-b <bookmark> --allow-new`
+  5. Two commands to push the bookmark:
+     - `jj bookmark track <bookmark>@origin` to track the bookmark on remote
+     - `jj git push -b <bookmark>` to push the changes to remote
   6. `gh pr create` command:
      - **IMPORTANT: use `--head <bookmark>` flag** (jj does not use git branches, so branch detection fails without this)
      - title:
@@ -30,7 +32,7 @@ After understanding the changes, generate a commit message in English.
      - assignee: same as issue (`@me`)
   7. `gh pr merge <pr-number>` command to merge the pull request
   8. cleanup commands:
-     - `jj git fetch && jj rebase -d main && jj bookmark delete <bookmark>`
+     - `jj git fetch && jj rebase -o main && jj bookmark delete <bookmark>`
 - Do not show the commit message separately; only show it in the commands.
 - Do not execute any commands, only show them for the user to run manually.
 - When you need to check diffs, status, or logs, use `git` commands instead of `jj` commands.


### PR DESCRIPTION
- replace removed `--allow-new` with `jj bookmark track` +
  `jj git push` in claude and gemini commands
- replace deprecated `rebase -d` with `rebase -o` (`--onto`)
  in claude and gemini commands

closes #1461