### PR TITLE
🐞fix(nvim): suppress log noise and fix integrations

### DIFF
--- a/configs/efm-langserver/config.yaml
+++ b/configs/efm-langserver/config.yaml
@@ -1,0 +1,1 @@
+version: 2

--- a/configs/nvim/lua/config/options.lua
+++ b/configs/nvim/lua/config/options.lua
@@ -65,3 +65,35 @@ vim.opt.cmdheight = 0 -- hide command line (bottom of the screen) because of usi
 vim.opt.display = "lastline" -- show last line of the screen
 -- persist undo
 vim.opt.undofile = true
+-- suppress noisy LSP log messages
+local lsp_log_suppress = {
+	"chat-lib-tokenizer",
+	"reading on stdin, writing on stdout",
+	"connections closed",
+	"connection is closed",
+	"document not found: term://",
+}
+vim.lsp.log.set_format_func(function(level, ...)
+	if vim.log.levels[level] ~= nil and vim.log.levels[level] < vim.lsp.log.get_level() then
+		return nil
+	end
+	local argc = select("#", ...)
+	for i = 1, argc do
+		local arg = select(i, ...)
+		if type(arg) == "string" then
+			for _, pattern in ipairs(lsp_log_suppress) do
+				if arg:find(pattern, 1, true) then
+					return nil
+				end
+			end
+		end
+	end
+	local info = debug.getinfo(2, "Sl")
+	local header = string.format("[%s][%s] %s:%s", level, os.date("%F %H:%M:%S"), info.short_src, info.currentline)
+	local parts = { header }
+	for i = 1, argc do
+		local arg = select(i, ...)
+		table.insert(parts, arg == nil and "nil" or vim.inspect(arg, { newline = " ", indent = "" }))
+	end
+	return table.concat(parts, "\t") .. "\n"
+end)

--- a/configs/nvim/lua/plugins/languages/completion/copilot.lua
+++ b/configs/nvim/lua/plugins/languages/completion/copilot.lua
@@ -46,6 +46,25 @@ return {
 				suggestion = { enabled = false },
 				-- disable panel
 				panel = { enabled = false },
+				-- jj detached HEAD triggers Copilot node agent warnings; filter at handler level
+				server_opts_overrides = {
+					handlers = {
+						["window/logMessage"] = function(err, result, ctx, config)
+							local filtered = {
+								"Local Diff Tracker",
+								"Policy watcher not available",
+							}
+							if result and result.message then
+								for _, pattern in ipairs(filtered) do
+									if result.message:find(pattern) then
+										return
+									end
+								end
+							end
+							vim.lsp.handlers["window/logMessage"](err, result, ctx, config)
+						end,
+					},
+				},
 			})
 		end,
 	},

--- a/configs/nvim/lua/plugins/languages/lsp/servers/efm.lua
+++ b/configs/nvim/lua/plugins/languages/lsp/servers/efm.lua
@@ -2,6 +2,13 @@
 local M = {}
 function M.setup()
 	vim.lsp.config("efm", {
+		root_dir = function(bufnr, on_dir)
+			if vim.api.nvim_buf_get_name(bufnr):match("^term://") then
+				on_dir(nil)
+				return
+			end
+			on_dir(vim.fs.root(bufnr, { ".git" }) or vim.fn.getcwd())
+		end,
 		init_options = {
 			documentFormatting = true,
 			documentRangeFormatting = true,

--- a/configs/nvim/lua/plugins/ui/components/lualine_nvim.lua
+++ b/configs/nvim/lua/plugins/ui/components/lualine_nvim.lua
@@ -271,6 +271,16 @@ return {
 						return require("screenkey").get_keys()
 					end,
 				},
+				-- __wakatime_statusline flag makes vim-wakatime skip auto-inserting into lualine_x
+				wakatime = {
+					function()
+						return require("wakatime").statusline()
+					end,
+					cond = function()
+						return require("wakatime").statusline() ~= ""
+					end,
+					__wakatime_statusline = true,
+				},
 				lsp = {
 					get_lsp_info,
 					color = { gui = "bold" },
@@ -404,6 +414,7 @@ return {
 					},
 					lualine_x = {
 						components.screenkey,
+						components.wakatime,
 						components.diagnostics,
 						components.lsp,
 						components.spaces,
@@ -426,6 +437,7 @@ return {
 					},
 					lualine_x = {
 						components.screenkey,
+						components.wakatime,
 						components.diagnostics,
 						components.lsp,
 						components.spaces,

--- a/configs/nvim/lua/plugins/ui/components/noice_nvim.lua
+++ b/configs/nvim/lua/plugins/ui/components/noice_nvim.lua
@@ -203,7 +203,18 @@ return {
 				},
 				throttle = 1000 / 30, -- how frequently does Noice need to check for ui updates? This has no effect when in blocking mode.
 				views = {}, ---@see section on views
-				routes = {}, --- @see section on routes
+				routes = {
+					{
+						filter = {
+							any = {
+								{ event = "msg_show", kind = "echomsg", find = "deprecated" },
+								{ event = "notify", kind = "info", find = "%[WakaTime%] Debug mode enabled" },
+								{ event = "notify", kind = "info", find = "%[WakaTime%] Initialized" },
+							},
+						},
+						opts = { skip = true },
+					},
+				}, --- @see section on routes
 				status = {}, --- @see section on statusline components
 				format = {}, --- @see section on formatting
 			})

--- a/configs/zsh/rc/abbreviations.zsh
+++ b/configs/zsh/rc/abbreviations.zsh
@@ -74,7 +74,7 @@ abbrev-alias trello="trello-tui -board yanoBoard"
 
 # shell
 ## reload zsh
-abbrev-alias reload="exec zsh"
+abbrev-alias reload="unset __HM_SESS_VARS_SOURCED LD_LIBRARY_PATH && exec zsh"
 
 # utilities
 ## nix-latest

--- a/outputs/home-manager/shared-modules/cli/development.nix
+++ b/outputs/home-manager/shared-modules/cli/development.nix
@@ -4,11 +4,13 @@
   # home
   home = {
     packages = with pkgs; [
+      glib.out
+      libsecret
       stdenv.cc.cc.lib
       vips
     ];
     sessionVariables = {
-      LD_LIBRARY_PATH = "\${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.vips}/lib";
+      LD_LIBRARY_PATH = "\${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${pkgs.glib.out}/lib:${pkgs.libsecret}/lib:${pkgs.stdenv.cc.cc.lib}/lib:${pkgs.vips}/lib";
     };
   };
 }


### PR DESCRIPTION
- suppress noisy LSP log messages via `set_format_func`
- filter `deprecated` and WakaTime notifications in `noice`
- filter Copilot agent warnings via `window/logMessage`
- stop `efm` from attaching to `term://` buffers
- show WakaTime statusline right of `screenkey` in `lualine`
- add `efm-langserver` v2 config
- add `glib`/`libsecret` to `LD_LIBRARY_PATH`
- unset stale env vars on `reload`

closes #1464