### PR TITLE
🐞fix(hypr): exec dispatch for special workspaces

### DIFF
--- a/configs/hypr/hyprland.conf
+++ b/configs/hypr/hyprland.conf
@@ -88,9 +88,9 @@ exec-once = sleep 1 && fcitx5 -D
 ## easyeffects
 exec-once = sleep 10 && easyeffects -w
 ## vesktop
-exec-once = vesktop
+exec-once = [workspace special:vesktop silent] vesktop
 ## spotify
-exec-once = spotify
+exec-once = [workspace special:spotify silent] spotify
 ## btop in special workspace
 exec-once = [workspace special:btop silent] wezterm -e btop
 ## steam


### PR DESCRIPTION
- use exec dispatch rule `[workspace special:xxx silent]` on startup
  for `vesktop` and `spotify`
- `windowrule` alone was unreliable due to class name timing mismatch
  on startup
- aligns with existing `btop` pattern already using exec dispatch

closes #1470