### PR TITLE
✨feat(nixos): add /bin/bash symlink

### DIFF
--- a/outputs/nixos/shared-modules/shell.nix
+++ b/outputs/nixos/shared-modules/shell.nix
@@ -1,4 +1,5 @@
 # nixos shell module
+{ pkgs, lib, ... }:
 {
   # programs
   programs = {
@@ -6,4 +7,11 @@
       enable = true;
     };
   };
+
+  # /bin/bash symlink for third-party scripts with hardcoded shebangs
+  system.activationScripts.binbash = lib.stringAfter [ "usrbinenv" ] ''
+    if [ ! -e /bin/bash ]; then
+      ln -s "${pkgs.bash}/bin/bash" /bin/bash
+    fi
+  '';
 }


### PR DESCRIPTION
- add `system.activationScripts.binbash` to `shell.nix`
- create `/bin/bash` symlink pointing to `pkgs.bash` in the
  nix store on system activation
- workaround for third-party scripts with hardcoded `#
  shebangs such as claude code plugin hooks

closes #1472